### PR TITLE
Fixes query encoding to be like Quickbooks expects it. closes #6

### DIFF
--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -52,7 +52,7 @@ module Quickbooks
       end
 
       def url_for_query(query = "")
-        "#{url_for_base}/query?query=#{URI.encode(query)}"
+        "#{url_for_base}/query?query=#{URI.encode_www_form_component(query)}"
       end
 
       private

--- a/spec/lib/quickbooks/service/base_service_spec.rb
+++ b/spec/lib/quickbooks/service/base_service_spec.rb
@@ -1,0 +1,14 @@
+describe Quickbooks::Service::BaseService do
+  before(:all) do
+    subject.realm_id = 1234
+  end
+
+  describe "#url_for_query" do
+    it "correctly encodes the query" do
+      query = "SELECT * FROM Customer where Name = 'John'"
+
+      correct_url = "https://qb.sbfinance.intuit.com/v3/company/1234/query?query=SELECT+*+FROM+Customer+where+Name+%3D+%27John%27"
+      subject.url_for_query(query).should == correct_url
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ require 'rubygems'
 require 'rspec'
 require 'fakeweb'
 require 'oauth'
-require 'quickbooks'
+require 'quickbooks-ruby'
 require 'json'
 
 Dir[File.expand_path('../support/**/*.rb', __FILE__)].each { |f| require f }


### PR DESCRIPTION
Quickbooks [querying documentation](https://developer.intuit.com/docs/0025_quickbooksapi/0050_data_services/020_key_concepts/00300_query_operations) doesn't mention it explicitly, but it requires the query param to be encoded like form data.

So if your query had elements like `' " + = > < ]`, `URI.encode` would leave them as is, what would give as an error. 

`URI.encode_www_form_component` does the job correctly encoding the param as it should.

This fixed my issue #6.

Thanks! :beer: 
