### PR TITLE
Include error message detail in request exception.

### DIFF
--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -266,7 +266,7 @@ module Quickbooks
 
       def parse_and_raise_exception
         err = parse_intuit_error
-        ex = IntuitRequestException.new(err[:message])
+        ex = IntuitRequestException.new("#{err[:message]}:\n\t#{err[:detail]}")
         ex.code = err[:code]
         ex.detail = err[:detail]
         ex.type = err[:type]


### PR DESCRIPTION
Not sure if a multiline exception is the right way to go here, but it'd be nice to see the error when the exception is thrown.

Before:

```
IntuitRequestException: Required param missing, need to supply the required value for the API
[Stack Trace]
```

After:

```
IntuitRequestException: Required param missing, need to supply the required value for the API:
    Required parameter Line.DetailType is missing in the request
[Stack Trace]
```

Other options:
Use the detail as the error message.
Other based on message type.

Let me know what you think.
