### PR TITLE
Drop 1.8.7/REE/1.9.2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ This library communicates with the Quickbooks Data Services `v3` API, documented
 
 ## Requirements
 
-This is being developed on Ruby REE, 1.9.2 & 1.9.3. Other versions/VMs are untested but stable Rubies should work in theory.
+This has been tested on 1.9.3, 2.0.0, and 2.1.0.
+
+Ruby 1.8.7 and 1.9.2 are not supported.
 
 ## Dependencies
 

--- a/quickbooks-ruby.gemspec
+++ b/quickbooks-ruby.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'oauth'
   gem.add_dependency 'roxml'
-  gem.add_dependency 'nokogiri', '~> 1.5.9'
+  gem.add_dependency 'nokogiri'
   gem.add_dependency 'activemodel'
 
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
This removes the Nokogiri version lock, which means that 1.8.7/REE is no longer supported. Also, a fresh install grabs an activemodel/activesupport that requires 1.9.3, so 1.9.2 is out as well. That is less of a problem for anyone.

Also, the README has been updated to reflect this. We ran tests on 1.9.3, 2.0.0, and 2.1.0 with no problems. I highly recommend adding the gem to [Travis CI](https://travis-ci.org/) so you can see at a glance what versions do and don't work.

Fixes #28 
