### PR TITLE
Remove Job from implemented entities list

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,6 @@ Estimate           | yes    | yes    | yes  | yes    | yes         |
 Invoice           | yes    | yes    | yes  | yes    | yes         |
 Item              | yes    | yes    | yes  | yes    | yes         |
 Journal Entry     | no    | no    | no  | no    | no         |
-Job               | no    | no    | no  | no    | no         |
 Payment           | yes    | yes    | yes  | yes    | yes         |
 PaymentMethod     | yes    | yes    | yes  | yes    | yes         |
 Preferences           | no    | no    | no  | no    | no         |


### PR DESCRIPTION
It's not necessary to list Job as unimplemented, as Customers are now Jobs if certain attributes are set (specifically, `Job` and `ParentRef`). These attributes are already implemented in the Customer model, so this README change is all that's really needed.

For more info, see the [QBO V2 to V3 Migration Guide](https://developer.intuit.com/docs/0025_quickbooksapi/0058_faq/qbo_v2_to_v3_migration_guide#Jobs_%28subcustomers%29).
