### PR TITLE
Fixes #36

### DIFF
--- a/lib/quickbooks/version.rb
+++ b/lib/quickbooks/version.rb
@@ -1,5 +1,5 @@
 module Quickbooks
 
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 
 end

--- a/quickbooks-ruby.gemspec
+++ b/quickbooks-ruby.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'oauth'
   gem.add_dependency 'roxml'
-  gem.add_dependency 'nokogiri'
+  gem.add_dependency 'nokogiri', '~> 1.6', '>= 1.6.1'
   gem.add_dependency 'activemodel'
 
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
- update nokogiri runtime dependency to '~> 1.6', '>= 1.6.1'
- bump the gem version
