### PR TITLE
Kept receving a:

### DIFF
--- a/quickbooks-ruby.gemspec
+++ b/quickbooks-ruby.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'oauth'
   gem.add_dependency 'roxml'
-  gem.add_dependency 'nokogiri', '~> 1.6', '>= 1.6.1'
+  gem.add_dependency 'nokogiri' # leave in promiscuous mode so as to not conflict with quickeebooks gem
   gem.add_dependency 'activemodel'
 
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
```
Fetching source index from http://rubygems.org/
Resolving dependencies...
Bundler could not find compatible versions for gem "nokogiri":
  In Gemfile:
    quickeebooks (>= 0) ruby depends on
      nokogiri (~> 1.5.9) ruby

    nokogiri (1.6.1)
```

.. when trying to bundle in a client project
after updating quickbooks-ruby to the latest. Removing the
pessimistic constraint allowed the bundle to go thru fine.

Let's roll back this change as many apps are going to be running
quickeebooks also.
