### PR TITLE
Keep ship_method_ref as a simple string

### DIFF
--- a/lib/quickbooks/model/sales_receipt.rb
+++ b/lib/quickbooks/model/sales_receipt.rb
@@ -19,7 +19,7 @@ module Quickbooks
 
       xml_accessor :po_number, :from => 'PONumber'
 
-      xml_accessor :ship_method_ref, :from => 'ShipMethodRef', :as => BaseReference
+      xml_accessor :ship_method_ref, :from => 'ShipMethodRef'
       xml_accessor :ship_date, :from => 'ShipDate', :as => Time
       xml_accessor :tracking_num, :from => 'TrackingNum'
 


### PR DESCRIPTION
Even though quickbooks api tells it is a ReferenceType I don't any
ShipMethod type on their docs or UI. Setting a name to the shipping
method works just fine though. The name is properly displayed on the
sales receipt page.

Does that make sense?

Sales order reference doc: https://developer.intuit.com/docs/0025_quickbooksapi/0050_data_services/030_entity_services_reference/salesreceipt