### PR TITLE
Use response.plain_body in AccessToken Service

### DIFF
--- a/lib/quickbooks/service/access_token.rb
+++ b/lib/quickbooks/service/access_token.rb
@@ -12,7 +12,7 @@ module Quickbooks
         if response
           code = response.code.to_i
           if code == 200
-            result = Quickbooks::Model::AccessTokenResponse.from_xml(response.body)
+            result = Quickbooks::Model::AccessTokenResponse.from_xml(response.plain_body)
           end
         end
 
@@ -26,7 +26,7 @@ module Quickbooks
         if response
           code = response.code.to_i
           if code == 200
-            result = Quickbooks::Model::AccessTokenResponse.from_xml(response.body)
+            result = Quickbooks::Model::AccessTokenResponse.from_xml(response.plain_body)
           end
         end
 


### PR DESCRIPTION
response.plain_body should be used insteand of response.body
