### PR TITLE
Threading through initializer arguments

### DIFF
--- a/lib/quickbooks/model/estimate.rb
+++ b/lib/quickbooks/model/estimate.rb
@@ -52,7 +52,7 @@ module Quickbooks
       validates_length_of :line_items, :minimum => 1
       validate :existence_of_customer_ref
 
-      def initialize
+      def initialize(*args)
         ensure_line_items_initialization
         super
       end

--- a/lib/quickbooks/model/invoice.rb
+++ b/lib/quickbooks/model/invoice.rb
@@ -57,7 +57,7 @@ module Quickbooks
       validate :existence_of_customer_ref
       validate :required_bill_email_if_email_delivery
 
-      def initialize
+      def initialize(*args)
         ensure_line_items_initialization
         super
       end

--- a/lib/quickbooks/model/item.rb
+++ b/lib/quickbooks/model/item.rb
@@ -54,7 +54,7 @@ module Quickbooks
       validates_length_of :name, :minimum => 1
       validates_inclusion_of :type, :in => ITEM_TYPES
 
-      def initialize
+      def initialize(*args)
         self.type = INVENTORY_TYPE
         super
       end


### PR DESCRIPTION
This makes sure that all models with overridden `initialize` methods pass their arguments through to their `super`.
