### PR TITLE
Adding reference_setters to TransactionTaxDetail

### DIFF
--- a/lib/quickbooks/model/transaction_tax_detail.rb
+++ b/lib/quickbooks/model/transaction_tax_detail.rb
@@ -6,6 +6,7 @@ module Quickbooks
       xml_accessor :total_tax, :from => 'TotalTax', :as => BigDecimal, :to_xml => :to_f.to_proc
       xml_accessor :lines, :from => 'TaxLine', :as => [TaxLine]
 
+      reference_setters :txn_tax_code_ref
     end
   end
 end

--- a/spec/lib/quickbooks/model/transaction_tax_detail_spec.rb
+++ b/spec/lib/quickbooks/model/transaction_tax_detail_spec.rb
@@ -1,0 +1,7 @@
+describe "Quickbooks::Model::TransactionTaxDetail" do
+  it "allows setting of the TxnTaxCodeRef via #txn_tax_code_ref_id=" do
+    transaction_tax_detail = Quickbooks::Model::TransactionTaxDetail.new
+    transaction_tax_detail.txn_tax_code_id = 42
+    transaction_tax_detail.txn_tax_code_ref.value.should == 42
+  end
+end


### PR DESCRIPTION
This commit adds the ability to set the transaction tax code ID on `TransactionTaxDetail` models via `#txn_tax_code_id`.
