### PR TITLE
By default, pretty print the xml when logging for easy reading. There

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ By default, logging is directed at STDOUT, but another target may be defined, e.
 ```ruby
 Quickbooks.logger = Rails.logger
 Quickbooks.log = true
+Quickbooks.log_xml_pretty_print = false
 ```
 
 ## Entities Implemented
@@ -348,7 +349,7 @@ Cody Caughlan
 your name please email me or submit a Pull Request.
 
 * Bruno Buccolo
-* Christian
+* Christian Pelczarski
 * Eggy
 * Evan Walsh
 * Exe Curia

--- a/lib/quickbooks-ruby.rb
+++ b/lib/quickbooks-ruby.rb
@@ -112,11 +112,16 @@ module Quickbooks
     end
 
     # set logging on or off
-    attr_writer :log
+    attr_writer :log, :log_xml_pretty_print
 
     # Returns whether to log. Defaults to 'false'.
     def log?
       @log ||= false
+    end
+
+    # pretty printing the xml in the logs is "on" by default
+    def log_xml_pretty_print?
+      defined?(@log_xml_pretty_print) ? @log_xml_pretty_print : true
     end
 
     def log(msg)

--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -194,11 +194,12 @@ module Quickbooks
           headers['Accept-Encoding'] = HTTP_ACCEPT_ENCODING
         end
 
-        log "------ New Request ------"
+        log "------ QUICKBOOKS-RUBY REQUEST ------"
         log "METHOD = #{method}"
         log "RESOURCE = #{url}"
-        log "BODY(#{body.class}) = #{body == nil ? "<NIL>" : body.inspect}"
-        log "HEADERS = #{headers.inspect}"
+        log "REQUEST BODY:"
+        log(log_xml(body))
+        log "REQUEST HEADERS = #{headers.inspect}"
 
         response = case method
           when :get
@@ -220,8 +221,10 @@ module Quickbooks
       end
 
       def check_response(response)
+        log "------ QUICKBOOKS-RUBY RESPONSE ------"
         log "RESPONSE CODE = #{response.code}"
-        log "RESPONSE BODY = #{response.plain_body}"
+        log "RESPONSE BODY:"
+        log(log_xml(response.plain_body))
         parse_xml(response.plain_body)
         status = response.code.to_i
         case status

--- a/lib/quickbooks/util/logging.rb
+++ b/lib/quickbooks/util/logging.rb
@@ -4,6 +4,16 @@ module Quickbooks
       def log(msg)
         ::Quickbooks.log(msg)
       end
+
+      def log_xml(str)
+        if ::Quickbooks.log_xml_pretty_print? && !(str and str.empty?)
+          Nokogiri::XML(str).to_xml
+        else
+          str
+        end
+      rescue => e
+        e
+      end
     end
   end
 end


### PR DESCRIPTION
are some other logging enhancements like clearly declaring a
quickbooks-ruby request/response.
