### PR TITLE
Allow users to construct a service with the access token and realm included in the initializer

### DIFF
--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -15,8 +15,9 @@ module Quickbooks
       HTTP_ACCEPT = 'application/xml'
       HTTP_ACCEPT_ENCODING = 'gzip, deflate'
 
-      def initialize()
+      def initialize(attributes = {})
         @base_uri = 'https://qb.sbfinance.intuit.com/v3/company'
+        attributes.each {|key, value| public_send("#{key}=", value) }
       end
 
       def access_token=(token)

--- a/spec/lib/quickbooks/service/base_service_spec.rb
+++ b/spec/lib/quickbooks/service/base_service_spec.rb
@@ -10,6 +10,18 @@ describe Quickbooks::Service::BaseService do
     end
   end
 
+  describe 'constructor' do
+    before do
+      construct_compact_service :base_service
+    end
+
+    it "correctly initializes with an access_token and realm" do
+      @service.company_id.should == "9991111222"
+      puts
+      @service.oauth.is_a?(OAuth::AccessToken).should == true
+    end
+  end
+
   describe 'check_response' do
     before do
       construct_service :base_service

--- a/spec/support/oauth_helpers.rb
+++ b/spec/support/oauth_helpers.rb
@@ -17,6 +17,10 @@ module OauthHelpers
     @service.access_token = construct_oauth
     @service.company_id = "9991111222"
   end
+
+  def construct_compact_service(model)
+    @service = "Quickbooks::Service::#{model.to_s.camelcase}".constantize.new(access_token: construct_oauth, company_id:"9991111222")    
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
...just like the `BaseModel` class allows.

This is just a convenience thing so i can do something like:

``` ruby
  def customer_service
    Quickbooks::Service::Customer.new(access_token: access_token, company_id: realm)
  end
```

Passing test included.
