### PR TITLE
Attributes total_tax within the TransactionTaxDetail model and rate_percent ....

### DIFF
--- a/lib/quickbooks/model/sales_item_line_detail.rb
+++ b/lib/quickbooks/model/sales_item_line_detail.rb
@@ -4,7 +4,7 @@ module Quickbooks
       xml_accessor :item_ref, :from => 'ItemRef', :as => BaseReference
       xml_accessor :class_ref, :from => 'ClassRef', :as => BaseReference
       xml_accessor :unit_price, :from => 'UnitPrice', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
-      xml_accessor :rate_percent, :from => 'RatePercent', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
+      xml_accessor :rate_percent, :from => 'RatePercent', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :price_level_ref, :from => 'PriceLevelRef', :as => BaseReference
       xml_accessor :quantity, :from => 'Qty', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
       xml_accessor :tax_code_ref, :from => 'TaxCodeRef', :as => BaseReference

--- a/lib/quickbooks/model/tax_line_detail.rb
+++ b/lib/quickbooks/model/tax_line_detail.rb
@@ -2,7 +2,7 @@ module Quickbooks
   module Model
     class TaxLineDetail < BaseModel
 
-      xml_accessor :percent_based, :from => 'PercentBased'
+      xml_accessor :percent_based?, :from => 'PercentBased'
       xml_accessor :net_amount_taxable, :from => 'NetAmountTaxable', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
       xml_accessor :tax_inclusive_amount, :from => 'TaxInclusiveAmount', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
       xml_accessor :override_delta_amount, :from => 'OverrideDeltaAmount', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }

--- a/lib/quickbooks/model/transaction_tax_detail.rb
+++ b/lib/quickbooks/model/transaction_tax_detail.rb
@@ -3,7 +3,7 @@ module Quickbooks
     class TransactionTaxDetail < BaseModel
 
       xml_accessor :txn_tax_code_ref, :from => 'TxnTaxCodeRef', :as => BaseReference
-      xml_accessor :total_tax, :from => 'TotalTax', :as => BigDecimal, :to_xml => :to_f.to_proc
+      xml_accessor :total_tax, :from => 'TotalTax', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :lines, :from => 'TaxLine', :as => [TaxLine]
 
       reference_setters :txn_tax_code_ref

--- a/spec/lib/quickbooks/model/invoice_spec.rb
+++ b/spec/lib/quickbooks/model/invoice_spec.rb
@@ -63,14 +63,14 @@ describe "Quickbooks::Model::Invoice" do
     first_tax_line.amount.should eq(0)
     first_tax_line.detail_type.should eq("TaxLineDetail")
     first_tax_line.tax_line_detail.tax_rate_ref.value.should eq("4")
-    first_tax_line.tax_line_detail.percent_based.should eq("true")
+    first_tax_line.tax_line_detail.percent_based?.should be_true
     first_tax_line.tax_line_detail.tax_percent.should eq(0.0)
     first_tax_line.tax_line_detail.net_amount_taxable.should eq(4.0)
 
     second_tax_line.amount.should eq(2.85)
     second_tax_line.detail_type.should eq("TaxLineDetail")
     second_tax_line.tax_line_detail.tax_rate_ref.value.should eq("20")
-    second_tax_line.tax_line_detail.percent_based.should eq("true")
+    second_tax_line.tax_line_detail.percent_based?.should be_true 
     second_tax_line.tax_line_detail.tax_percent.should eq(10.0)
     second_tax_line.tax_line_detail.net_amount_taxable.should eq(28.5)
 

--- a/spec/lib/quickbooks/model/purchase_spec.rb
+++ b/spec/lib/quickbooks/model/purchase_spec.rb
@@ -44,7 +44,7 @@ describe "Quickbooks::Model::Purchase" do
     tax_line1.detail_type.should == "TaxLineDetail"
     tax_line1.amount.should == 2.0
     tax_line1.tax_line_detail.tax_rate_ref.value.should == "4"
-    tax_line1.tax_line_detail.percent_based.should == "true"
+    tax_line1.tax_line_detail.percent_based?.should be_true
     tax_line1.tax_line_detail.tax_percent.should == 20
     tax_line1.tax_line_detail.net_amount_taxable.should == 10.0
 
@@ -52,7 +52,7 @@ describe "Quickbooks::Model::Purchase" do
     tax_line2.detail_type.should == "TaxLineDetail"
     tax_line2.amount.should == -2.0
     tax_line2.tax_line_detail.tax_rate_ref.value.should == "3"
-    tax_line2.tax_line_detail.percent_based.should == "true"
+    tax_line2.tax_line_detail.percent_based?.should be_true
     tax_line2.tax_line_detail.tax_percent.should == -20
     tax_line2.tax_line_detail.net_amount_taxable.should == 10.0
 
@@ -60,7 +60,7 @@ describe "Quickbooks::Model::Purchase" do
     tax_line3.detail_type.should == "TaxLineDetail"
     tax_line3.amount.should == 0.05
     tax_line3.tax_line_detail.tax_rate_ref.value.should == "8"
-    tax_line3.tax_line_detail.percent_based.should == "true"
+    tax_line3.tax_line_detail.percent_based?.should be_true
     tax_line3.tax_line_detail.tax_percent.should == 5
     tax_line3.tax_line_detail.net_amount_taxable.should == 1.0
   end
@@ -120,7 +120,7 @@ describe "Quickbooks::Model::Purchase" do
     tax_line1.detail_type.should == "TaxLineDetail"
     tax_line1.amount.should == 2.0
     tax_line1.tax_line_detail.tax_rate_ref.value.should == "4"
-    tax_line1.tax_line_detail.percent_based.should == "true"
+    tax_line1.tax_line_detail.percent_based?.should be_true
     tax_line1.tax_line_detail.tax_percent.should == 20
     tax_line1.tax_line_detail.net_amount_taxable.should == 10.0
 
@@ -128,7 +128,7 @@ describe "Quickbooks::Model::Purchase" do
     tax_line2.detail_type.should == "TaxLineDetail"
     tax_line2.amount.should == -2.0
     tax_line2.tax_line_detail.tax_rate_ref.value.should == "3"
-    tax_line2.tax_line_detail.percent_based.should == "true"
+    tax_line2.tax_line_detail.percent_based?.should be_true
     tax_line2.tax_line_detail.tax_percent.should == -20
     tax_line2.tax_line_detail.net_amount_taxable.should == 10.0
 
@@ -136,7 +136,7 @@ describe "Quickbooks::Model::Purchase" do
     tax_line3.detail_type.should == "TaxLineDetail"
     tax_line3.amount.should == 0.05
     tax_line3.tax_line_detail.tax_rate_ref.value.should == "8"
-    tax_line3.tax_line_detail.percent_based.should == "true"
+    tax_line3.tax_line_detail.percent_based?.should be_true
     tax_line3.tax_line_detail.tax_percent.should == 5
     tax_line3.tax_line_detail.net_amount_taxable.should == 1.0
   end

--- a/spec/lib/quickbooks/model/sales_line_item_detail_spec.rb
+++ b/spec/lib/quickbooks/model/sales_line_item_detail_spec.rb
@@ -1,0 +1,13 @@
+describe "Quickbooks::Model::SalesItemLineDetail" do
+
+  it "rate percent should be a decimal/float if set" do
+    detail = Quickbooks::Model::SalesItemLineDetail.new
+    detail.rate_percent = 10
+    detail.to_xml.at_css('RatePercent').content.should == '10.0'
+  end
+
+  it "rate percent should not be included if not set" do
+    detail = Quickbooks::Model::SalesItemLineDetail.new
+    detail.to_xml.should_not =~ /RatePercent/
+  end
+end

--- a/spec/lib/quickbooks/model/transaction_tax_detail_spec.rb
+++ b/spec/lib/quickbooks/model/transaction_tax_detail_spec.rb
@@ -1,7 +1,19 @@
 describe "Quickbooks::Model::TransactionTaxDetail" do
   it "allows setting of the TxnTaxCodeRef via #txn_tax_code_ref_id=" do
     transaction_tax_detail = Quickbooks::Model::TransactionTaxDetail.new
+    transaction_tax_detail.total_tax = 42
     transaction_tax_detail.txn_tax_code_id = 42
     transaction_tax_detail.txn_tax_code_ref.value.should == 42
+  end
+
+  it "total tax should be a decimal/float" do
+    transaction_tax_detail = Quickbooks::Model::TransactionTaxDetail.new
+    transaction_tax_detail.total_tax = 42
+    transaction_tax_detail.to_xml.at_css('TotalTax').content.should == '42.0'
+  end
+
+  it "total tax should not be included if not set" do
+    transaction_tax_detail = Quickbooks::Model::TransactionTaxDetail.new
+    transaction_tax_detail.to_xml.should_not =~ /TotalTax/
   end
 end


### PR DESCRIPTION
within the SalesItemLineDetail model should not be set by default. Using
the :to_xml with no nil? check automatically creates that attribute within
a request. Using the proc returned from to_xml_big_decimal method does
do a nil check and will not generate the node if the attribute is not set.

Lastly, the percent_based attribute
within the TaxLineDetail model should be a ROXML boolean.
