### PR TITLE
Fix account type without opening balances

### DIFF
--- a/lib/quickbooks/model/account.rb
+++ b/lib/quickbooks/model/account.rb
@@ -36,7 +36,7 @@ module Quickbooks
 
       xml_accessor :current_balance, :from => 'CurrentBalance', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
       xml_accessor :current_balance_with_sub_accounts, :from => 'CurrentBalanceWithSubAccounts', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
-      xml_accessor :opening_balance, :from => 'OpeningBalance', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
+      xml_accessor :opening_balance, :from => 'OpeningBalance', :as => BigDecimal, :to_xml => Proc.new { |val| val.nil? ? nil : val.to_f }
       xml_accessor :opening_balance_date, :from => 'OpeningBalanceDate', :as => DateTime
       xml_accessor :currency_ref, :from => 'CurrencyRef', :as => BaseReference
       xml_accessor :tax_account?, :from => 'TaxAccount'


### PR DESCRIPTION
Some account type doesn't support opening balances, this fixes it

```
Fix Quickbooks::IntuitRequestException: A business validation error has occurred while processing your request:
        Business Validation Error: This account type doesn't support opening balances.
```
