### PR TITLE
Fix CustomerRef

### DIFF
--- a/lib/quickbooks/model/invoice.rb
+++ b/lib/quickbooks/model/invoice.rb
@@ -101,8 +101,8 @@ module Quickbooks
       end
 
       def existence_of_customer_ref
-        if customer_ref.nil? || (customer_ref && customer_ref.value == 0)
-          errors.add(:customer_ref, "CustomerRef is required and must be a non-zero value.")
+        if customer_ref.nil? || (customer_ref && !customer_ref.active?)
+          errors.add(:customer_ref, "CustomerRef is required and must be active customer.")
         end
       end
 

--- a/lib/quickbooks/model/payment.rb
+++ b/lib/quickbooks/model/payment.rb
@@ -32,8 +32,8 @@ module Quickbooks
       private
 
       def existence_of_customer_ref
-        if customer_ref.nil? || (customer_ref && customer_ref.value == 0)
-          errors.add(:customer_ref, "CustomerRef is required and must be a non-zero value.")
+        if customer_ref.nil? || (customer_ref && !customer_ref.active?)
+          errors.add(:customer_ref, "CustomerRef is required and must be active customer.")
         end
       end
     end


### PR DESCRIPTION
On Invoice and Payment model, the existence_of_customer_ref validation is broken because `customer_ref` doesn't have `value` method or attributes.

```
NoMethodError: undefined method `value' for #<Quickbooks::Model::Customer:0x0000000931d748>
```
