### PR TITLE
Simplify service CRUD. The code for update and create was identical.

### DIFF
--- a/lib/quickbooks/service/service_crud.rb
+++ b/lib/quickbooks/service/service_crud.rb
@@ -21,6 +21,7 @@ module Quickbooks
           nil
         end
       end
+      alias :update :create
 
       def delete(entity)
         raise "Not implemented for this Entity"
@@ -37,21 +38,6 @@ module Quickbooks
           false
         end
       end
-
-      def update(entity, options = {})
-        unless entity.valid?
-          raise Quickbooks::InvalidModelException.new(entity.errors.full_messages.join(','))
-        end
-
-        xml = entity.to_xml_ns(options)
-        response = do_http_post(url_for_resource(model.resource_for_singular), valid_xml_document(xml))
-        if response.code.to_i == 200
-          model.from_xml(parse_singular_entity_response(model, response.plain_body))
-        else
-          nil
-        end
-      end
-
     end
   end
 end


### PR DESCRIPTION
The only difference was that the update did an `if` block and the create does an inline `if` so it makes sense to just combine them into one method and use an alias for backwards compatibility.

update:

``` ruby
unless entity.valid?
  raise Quickbooks::InvalidModelException.new(entity.errors.full_messages.join(','))
end
```

create:

``` ruby
raise Quickbooks::InvalidModelException.new(entity.errors.full_messages.join(',')) unless entity.valid?
```
