### PR TITLE
Make all BigDecimal :to_xml use the to_xml_big_decimal helper method.

### DIFF
--- a/lib/quickbooks/model/account.rb
+++ b/lib/quickbooks/model/account.rb
@@ -34,9 +34,9 @@ module Quickbooks
       xml_accessor :acct_num, :from => 'AcctNum'
       xml_accessor :bank_num, :from => 'BankNum'
 
-      xml_accessor :current_balance, :from => 'CurrentBalance', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
-      xml_accessor :current_balance_with_sub_accounts, :from => 'CurrentBalanceWithSubAccounts', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
-      xml_accessor :opening_balance, :from => 'OpeningBalance', :as => BigDecimal, :to_xml => Proc.new { |val| val.nil? ? nil : val.to_f }
+      xml_accessor :current_balance, :from => 'CurrentBalance', :as => BigDecimal, :to_xml => to_xml_big_decimal
+      xml_accessor :current_balance_with_sub_accounts, :from => 'CurrentBalanceWithSubAccounts', :as => BigDecimal, :to_xml => to_xml_big_decimal
+      xml_accessor :opening_balance, :from => 'OpeningBalance', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :opening_balance_date, :from => 'OpeningBalanceDate', :as => DateTime
       xml_accessor :currency_ref, :from => 'CurrencyRef', :as => BaseReference
       xml_accessor :tax_account?, :from => 'TaxAccount'

--- a/lib/quickbooks/model/account_based_expense_line_detail.rb
+++ b/lib/quickbooks/model/account_based_expense_line_detail.rb
@@ -5,7 +5,7 @@ module Quickbooks
       xml_accessor :class_ref, :from => 'ClassRef', :as => BaseReference
       xml_accessor :account_ref, :from => 'AccountRef', :as => BaseReference
       xml_accessor :billable_status, :from => 'BillableStatus'
-      xml_accessor :tax_amount, :from => 'UnitPrice', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
+      xml_accessor :tax_amount, :from => 'UnitPrice', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :tax_code_ref, :from => 'TaxCodeRef', :as => BaseReference
 
       reference_setters :customer_ref, :class_ref, :account_ref, :tax_code_ref

--- a/lib/quickbooks/model/base_model.rb
+++ b/lib/quickbooks/model/base_model.rb
@@ -47,7 +47,7 @@ module Quickbooks
 
       class << self
         def to_xml_big_decimal
-          Proc.new { |val| val.to_f unless val.nil? }
+          Proc.new { |val| val.nil? ? nil : val.to_f }
         end
 
         def attribute_names

--- a/lib/quickbooks/model/bill_line_item.rb
+++ b/lib/quickbooks/model/bill_line_item.rb
@@ -8,7 +8,7 @@ module Quickbooks
       xml_accessor :id, :from => 'Id', :as => Integer
       xml_accessor :line_num, :from => 'LineNum', :as => Integer
       xml_accessor :description, :from => 'Description'
-      xml_accessor :amount, :from => 'Amount', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
+      xml_accessor :amount, :from => 'Amount', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :detail_type, :from => 'DetailType'
 
       #== Various detail types

--- a/lib/quickbooks/model/bill_payment_line_item.rb
+++ b/lib/quickbooks/model/bill_payment_line_item.rb
@@ -9,7 +9,7 @@ module Quickbooks
       xml_accessor :id, :from => 'Id', :as => Integer
       xml_accessor :line_num, :from => 'LineNum', :as => Integer
       xml_accessor :description, :from => 'Description'
-      xml_accessor :amount, :from => 'Amount', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
+      xml_accessor :amount, :from => 'Amount', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :detail_type, :from => 'DetailType'
 
       xml_accessor :linked_transactions, :from => 'LinkedTxn', :as => [LinkedTransaction]

--- a/lib/quickbooks/model/customer.rb
+++ b/lib/quickbooks/model/customer.rb
@@ -42,9 +42,9 @@ module Quickbooks
       xml_accessor :level, :from => 'Level'
       xml_accessor :sales_term_ref, :from => 'SalesTermRef', :as => BaseReference
       xml_accessor :payment_method_ref, :from => 'PaymentMethodRef', :as => BaseReference
-      xml_accessor :balance, :from => 'Balance', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
+      xml_accessor :balance, :from => 'Balance', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :open_balance_date, :from => 'OpenBalanceDate', :as => Date
-      xml_accessor :balance_with_jobs, :from => 'BalanceWithJobs', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
+      xml_accessor :balance_with_jobs, :from => 'BalanceWithJobs', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :preferred_delivery_method, :from => 'PreferredDeliveryMethod'
       xml_accessor :resale_num, :from => 'ResaleNum'
       xml_accessor :suffix, :from => 'Suffix'

--- a/lib/quickbooks/model/discount_line_detail.rb
+++ b/lib/quickbooks/model/discount_line_detail.rb
@@ -4,7 +4,7 @@ module Quickbooks
     class DiscountLineDetail < BaseModel
       xml_accessor :discount_ref, :from => 'DiscountRef', :as => BaseReference
       xml_accessor :percent_based?, :from => 'PercentBased'
-      xml_accessor :discount_percent, :from => 'DiscountPercent', :as => BigDecimal, :to_xml => Proc.new { |val| val && val.to_f }
+      xml_accessor :discount_percent, :from => 'DiscountPercent', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :discount_account_ref, :from => 'DiscountAccountRef', :as => BaseReference
       xml_accessor :class_ref, :from => 'ClassRef', :as => BaseReference
       xml_accessor :tax_code_ref, :from => 'TaxCodeRef', :as => BaseReference

--- a/lib/quickbooks/model/discount_override.rb
+++ b/lib/quickbooks/model/discount_override.rb
@@ -3,7 +3,7 @@ module Quickbooks
     class DiscountOverride < BaseModel
       xml_accessor :discount_ref, :from => 'DiscountRef', :as => BaseReference
       xml_accessor :percent_based?, :from => 'PercentBased'
-      xml_accessor :discount_percent, :from => 'DiscountPercent', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
+      xml_accessor :discount_percent, :from => 'DiscountPercent', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :discount_account_ref, :from => 'DiscountAccountRef', :as => BaseReference
 
       reference_setters :discount_ref, :discount_account_ref

--- a/lib/quickbooks/model/employee.rb
+++ b/lib/quickbooks/model/employee.rb
@@ -31,7 +31,7 @@ module Quickbooks
       xml_accessor :ssn, :from => 'SSN'
       xml_accessor :address, :from => 'PrimaryAddr', :as => PhysicalAddress
       xml_accessor :billable?, :from => 'BillableTime'
-      xml_accessor :billable_rate, :from => 'BillRate', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
+      xml_accessor :billable_rate, :from => 'BillRate', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :birth_date, :from => 'BirthDate', :as => Date
       xml_accessor :gender, :from => 'Gender'
       xml_accessor :hired_date, :from => 'HiredDate', :as => Date

--- a/lib/quickbooks/model/estimate.rb
+++ b/lib/quickbooks/model/estimate.rb
@@ -21,7 +21,7 @@ module Quickbooks
       xml_accessor :doc_number, :from => 'DocNumber'
       xml_accessor :txn_date, :from => 'TxnDate', :as => Date
       xml_accessor :private_note, :from => 'PrivateNote'
-      
+
       xml_accessor :department_ref, :from => 'DepartmentRef', :as => BaseReference
       xml_accessor :linked_transactions, :from => 'LinkedTxn', :as => [LinkedTransaction]
       xml_accessor :line_items, :from => 'Line', :as => [InvoiceLineItem]
@@ -34,10 +34,10 @@ module Quickbooks
       xml_accessor :shipping_address, :from => 'ShipAddr', :as => PhysicalAddress
       xml_accessor :class_ref, :from => 'ClassRef', :as => BaseReference
       xml_accessor :sales_term_ref, :from => 'SalesTermRef', :as => BaseReference
-      xml_accessor :total_amount, :from => 'TotalAmt', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
+      xml_accessor :total_amount, :from => 'TotalAmt', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :ship_method_ref, :from => 'ShipMethodRef', :as => BaseReference
       xml_accessor :ship_date, :from => 'ShipDate', :as => Date
-     
+
       xml_accessor :apply_tax_after_discount?, :from => 'ApplyTaxAfterDiscount'
       xml_accessor :print_status, :from => 'PrintStatus'
       xml_accessor :email_status, :from => 'EmailStatus'

--- a/lib/quickbooks/model/group_line_detail.rb
+++ b/lib/quickbooks/model/group_line_detail.rb
@@ -2,7 +2,7 @@ module Quickbooks
   module Model
     class GroupLineDetail < BaseModel
       xml_accessor :group_item_ref, :from => 'CustomerRef', :as => BaseReference
-      xml_accessor :quantity, :from => 'Quantity', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
+      xml_accessor :quantity, :from => 'Quantity', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :line_items, :from => 'Line', :as => [Line]
 
       reference_setters :group_item_ref

--- a/lib/quickbooks/model/invoice.rb
+++ b/lib/quickbooks/model/invoice.rb
@@ -38,12 +38,12 @@ module Quickbooks
       xml_accessor :ship_date, :from => 'ShipDate', :as => Date
       xml_accessor :tracking_num, :from => 'TrackingNum'
       xml_accessor :ar_account_ref, :from => 'ARAccountRef', :as => BaseReference
-      xml_accessor :total_amount, :from => 'TotalAmt', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
+      xml_accessor :total_amount, :from => 'TotalAmt', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :apply_tax_after_discount?, :from => 'ApplyTaxAfterDiscount'
       xml_accessor :print_status, :from => 'PrintStatus'
       xml_accessor :email_status, :from => 'EmailStatus'
-      xml_accessor :balance, :from => 'Balance', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
-      xml_accessor :deposit, :from => 'Deposit', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
+      xml_accessor :balance, :from => 'Balance', :as => BigDecimal, :to_xml => to_xml_big_decimal
+      xml_accessor :deposit, :from => 'Deposit', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :department_ref, :from => 'DepartmentRef', :as => BaseReference
       xml_accessor :allow_ipn_payment?, :from => 'AllowIPNPayment'
       xml_accessor :bill_email, :from => 'BillEmail', :as => EmailAddress

--- a/lib/quickbooks/model/invoice_line_item.rb
+++ b/lib/quickbooks/model/invoice_line_item.rb
@@ -11,7 +11,7 @@ module Quickbooks
       xml_accessor :id, :from => 'Id', :as => Integer
       xml_accessor :line_num, :from => 'LineNum', :as => Integer
       xml_accessor :description, :from => 'Description'
-      xml_accessor :amount, :from => 'Amount', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
+      xml_accessor :amount, :from => 'Amount', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :detail_type, :from => 'DetailType'
 
       #== Various detail types

--- a/lib/quickbooks/model/item_based_expense_line_detail.rb
+++ b/lib/quickbooks/model/item_based_expense_line_detail.rb
@@ -3,11 +3,11 @@ module Quickbooks
     class ItemBasedExpenseLineDetail < BaseModel
       xml_accessor :item_ref, :from => 'ItemRef', :as => BaseReference
       xml_accessor :class_ref, :from => 'ClassRef', :as => BaseReference
-      xml_accessor :unit_price, :from => 'UnitPrice', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
-      xml_accessor :rate_percent, :from => 'RatePercent', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
+      xml_accessor :unit_price, :from => 'UnitPrice', :as => BigDecimal, :to_xml => to_xml_big_decimal
+      xml_accessor :rate_percent, :from => 'RatePercent', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :price_level_ref, :from => 'PriceLevelRef', :as => BaseReference
       xml_accessor :markup_info, :from => 'MarkupInfo', :as => MarkupInfo
-      xml_accessor :quantity, :from => 'Qty', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
+      xml_accessor :quantity, :from => 'Qty', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :tax_code_ref, :from => 'TaxCodeRef', :as => BaseReference
       xml_accessor :customer_ref, :from => 'CustomerRef', :as => BaseReference
       xml_accessor :billable_status, :from => 'BillableStatus'

--- a/lib/quickbooks/model/line.rb
+++ b/lib/quickbooks/model/line.rb
@@ -10,7 +10,7 @@ module Quickbooks
       xml_accessor :id, :from => 'Id', :as => Integer
       xml_accessor :line_num, :from => 'LineNum', :as => Integer
       xml_accessor :description, :from => 'Description'
-      xml_accessor :amount, :from => 'Amount', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
+      xml_accessor :amount, :from => 'Amount', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :detail_type, :from => 'DetailType'
 
       xml_accessor :linked_transactions, :from => 'LinkedTxn', :as => [LinkedTransaction]

--- a/lib/quickbooks/model/markup_info.rb
+++ b/lib/quickbooks/model/markup_info.rb
@@ -2,8 +2,8 @@ module Quickbooks
   module Model
     class MarkupInfo < BaseModel
       xml_accessor :percent_based, :from => 'PercentBased'
-      xml_accessor :value, :from => 'Value', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
-      xml_accessor :percent, :from => 'Percent', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
+      xml_accessor :value, :from => 'Value', :as => BigDecimal, :to_xml => to_xml_big_decimal
+      xml_accessor :percent, :from => 'Percent', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :price_level_ref, :from => 'PriceLevelRef', :as => BaseReference
 
       reference_setters :price_level_ref

--- a/lib/quickbooks/model/payment_line_detail.rb
+++ b/lib/quickbooks/model/payment_line_detail.rb
@@ -3,7 +3,7 @@ module Quickbooks
     class PaymentLineDetail < BaseModel
       xml_accessor :item_ref, :from => 'ItemRef', :as => BaseReference
       xml_accessor :class_ref, :from => 'ClassRef', :as => BaseReference
-      xml_accessor :balance, :from => 'Balance', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
+      xml_accessor :balance, :from => 'Balance', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :discount, :from => 'Discount', :as => DiscountOverride
 
       reference_setters :item_ref, :class_ref

--- a/lib/quickbooks/model/payment_method.rb
+++ b/lib/quickbooks/model/payment_method.rb
@@ -8,7 +8,7 @@ module Quickbooks
       xml_accessor :id, :from => 'Id', :as => Integer
       xml_accessor :name, :from => 'Name'
       xml_accessor :active?, :from => 'Active'
-      xml_accessor :amount, :from => 'Amount', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
+      xml_accessor :amount, :from => 'Amount', :as => BigDecimal, :to_xml => to_xml_big_decimal
     end
   end
 end

--- a/lib/quickbooks/model/purchase.rb
+++ b/lib/quickbooks/model/purchase.rb
@@ -24,7 +24,7 @@ module Quickbooks
       xml_accessor :doc_number, :from => 'DocNumber'
       xml_accessor :txn_date, :from => 'TxnDate', :as => Date
       xml_accessor :private_note, :from => 'PrivateNote'
-    
+
       xml_accessor :line_items, :from => 'Line', :as => [PurchaseLineItem]
       xml_accessor :account_ref, :from => 'AccountRef', :as => BaseReference
       xml_accessor :txn_tax_detail, :from => 'TxnTaxDetail', :as => TransactionTaxDetail
@@ -32,7 +32,7 @@ module Quickbooks
       xml_accessor :payment_type, :from => 'PaymentType'
       xml_accessor :entity_ref, :from => 'EntityRef', :as => BaseReference
       xml_accessor :remit_to_address, :from => 'RemitToAddr', :as => PhysicalAddress
-      xml_accessor :total_amount, :from => 'TotalAmt', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
+      xml_accessor :total_amount, :from => 'TotalAmt', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :print_status, :from => 'PrintStatus'
       xml_accessor :department_ref, :from => 'DepartmentRef', :as => BaseReference
 


### PR DESCRIPTION
Making all the `BigDecimal` `:to_xml` calls use the helper method so that we don't have a bunch of Procs strewn about the cdebase as well as making the overall codebase more consistent.

Thoughts about extending `BigDecimal` to just add a `:to_xml` method so we don't have to even have the code: `, :to_xml => to_xml_big_decimal`? Not sure if you averse to polluting base classes or not.
### Test restuls

``` bash
|2.0.0-p247| Marks-MacBook-Pro in ~/quickbooks-ruby
± |bigdecimal ✗| → rake spec

Finished in 1.13 seconds
187 examples, 0 failures
Coverage report generated for RSpec to /Users/mrickert/quickbooks-ruby/coverage. 1730 / 1809 LOC (95.63%) covered.
```
