### PR TITLE
Ensure line_items initialization when creating new SalesReceipt

### DIFF
--- a/lib/quickbooks/model/sales_receipt.rb
+++ b/lib/quickbooks/model/sales_receipt.rb
@@ -38,6 +38,11 @@ module Quickbooks
 
       validates_length_of :line_items, :minimum => 1
 
+      def initialize(*args)
+        ensure_line_items_initialization
+        super
+      end
+
       def email=(email)
         self.bill_email = EmailAddress.new(email)
       end

--- a/spec/lib/quickbooks/model/sales_receipt_spec.rb
+++ b/spec/lib/quickbooks/model/sales_receipt_spec.rb
@@ -39,4 +39,10 @@ describe "Quickbooks::Model::SalesReceipt" do
 
     sales_receipt.total.should == 10.00
   end
+
+  it "should initialize line items as empty array" do
+     sales_receipt = Quickbooks::Model::SalesReceipt.new
+     sales_receipt.line_items.should_not be_nil
+     sales_receipt.line_items.length.should == 0
+  end
 end


### PR DESCRIPTION
Quickbooks::Model::SalesReceipt.new.line_items was returning nil, causing the need to explicitly define line_items = [] when defining a new SalesReceipt.

This pull request puts Sales Receipts in line with Invoices, Credit memos and Estimates insofar as line_items are initialized as an empty array.
