### PR TITLE
Add inspect methods to models

### DIFF
--- a/lib/quickbooks/model/base_model.rb
+++ b/lib/quickbooks/model/base_model.rb
@@ -46,6 +46,12 @@ module Quickbooks
         self.line_items ||= []
       end
 
+      def inspect
+        # it would be nice if we could inspect all the children,
+        # but it's likely to blow the stack in some cases
+        "#<#{self.class} " + 
+        "#{attributes.map{|k,v| "#{k}: #{v.nil? ? 'nil' : v.to_s }"}.join ", "}>"
+      end
       class << self
         def to_xml_big_decimal
           Proc.new { |val| val.nil? ? nil : val.to_f }
@@ -85,6 +91,15 @@ module Quickbooks
           end
         end
 
+        def inspect
+          "#{super}(#{attrs_with_types.join " "})"
+        end
+        def attrs_with_types
+          roxml_attrs.map do |attr|
+            "#{attr.accessor}:" +
+              "#{attr.class.block_shorthands.invert[attr.blocks.last]}:#{attr.sought_type}"
+          end
+        end
       end
     end
   end

--- a/spec/lib/quickbooks/model/base_model_spec.rb
+++ b/spec/lib/quickbooks/model/base_model_spec.rb
@@ -63,4 +63,37 @@ describe "Quickbooks::Model::BaseModel" do
       bar_model.fetch(:foo).should eq(42)
     end
   end
+
+
+  describe ".inspect" do
+    it "should include the class name" do
+       Quickbooks::Model::FooModel.inspect.should match /\AQuickbooks::Model::FooModel/
+    end
+    it "should include the attribute keys" do
+      Quickbooks::Model::FooModel.inspect.should match /baz/
+    end
+    it "should include the attribute types" do
+      Quickbooks::Model::FooModel.inspect.should match /amount:BigDecimal/
+    end
+    it "should include the association type" do
+      Quickbooks::Model::FooModel.inspect.should match /bar:.+:Quickbooks::Model::BarModel/
+    end
+  end
+
+  describe "#inspect" do
+    it "should include the class name" do
+      foo_model.inspect.should match /\A#<Quickbooks::Model::FooModel.*>/
+    end
+    it "should include the attribute keys" do
+      foo_model.inspect.should match /baz/
+    end
+    it "should have nil values on init" do
+      Quickbooks::Model::FooModel.new.inspect.should match /baz: nil/
+    end
+    it "should show values if they are there" do
+      puts foo_model.inspect
+      foo_model.inspect.should match /baz: quux/
+    end
+  end
+
 end


### PR DESCRIPTION
This adds #inspect and .inspect to the models. A few notes:
- The type detection isn't all I'd like it to be, but ROXML doesn't make it easy to figure out what something was declared as.
- I'd like to inspect child models, but there would need to be cycle detection.
- I'm open to the idea that this should go in ROXML, but it also seems OK here.
- I'm in to the idea of adding inspect methods for services and collections too, but haven't quite figured out what it should look like(except for Service.inspect, which should probably just delegate to the model.)
