### PR TITLE
This adds each and enumerable to Collection

### DIFF
--- a/lib/quickbooks-ruby.rb
+++ b/lib/quickbooks-ruby.rb
@@ -7,6 +7,7 @@ require 'uri'
 require 'date'
 require 'forwardable'
 require 'oauth'
+require 'quickbooks/util/collection'
 require 'quickbooks/util/logging'
 require 'quickbooks/util/http_encoding_helper'
 require 'quickbooks/util/name_entity'
@@ -156,17 +157,6 @@ module Quickbooks
       self.message = msg
       super(msg)
     end
-  end
-
-
-  class Collection
-    attr_accessor :entries
-
-    # Legacy Attributes (v2)
-    attr_accessor :count, :current_page
-
-    # v3 Attributes
-    attr_accessor :start_position, :max_results, :total_count
   end
 
 end

--- a/lib/quickbooks/util/collection.rb
+++ b/lib/quickbooks/util/collection.rb
@@ -1,0 +1,16 @@
+module Quickbooks
+  class Collection
+    include Enumerable
+    attr_accessor :entries
+
+    # Legacy Attributes (v2)
+    attr_accessor :count, :current_page
+
+    # v3 Attributes
+    attr_accessor :start_position, :max_results, :total_count
+
+    def each(*args, &block)
+      (entries|| []).each *args, &block
+    end
+  end
+end

--- a/spec/lib/quickbooks/model/base_model_spec.rb
+++ b/spec/lib/quickbooks/model/base_model_spec.rb
@@ -91,7 +91,6 @@ describe "Quickbooks::Model::BaseModel" do
       Quickbooks::Model::FooModel.new.inspect.should match /baz: nil/
     end
     it "should show values if they are there" do
-      puts foo_model.inspect
       foo_model.inspect.should match /baz: quux/
     end
   end

--- a/spec/lib/quickbooks/util/collection_spec.rb
+++ b/spec/lib/quickbooks/util/collection_spec.rb
@@ -1,0 +1,16 @@
+describe Quickbooks::Collection do
+  it "is has an #each" do
+    collection = Quickbooks::Collection.new()
+    collection.entries = [:foo]
+    expect{ |b| collection.each &b}.to yield_with_args(:foo) 
+  end
+  it "has a method from enumerable" do
+    collection = Quickbooks::Collection.new()
+    collection.entries = [:foo]
+    expect( collection.first).to be(:foo)
+  end
+  it "doesn't error when no entries are set" do
+    collection = Quickbooks::Collection.new()
+    expect{collection.first}.to_not raise_error
+  end
+end


### PR DESCRIPTION
It also moves the collection class into it's own file, in util.

I'd like to eventually have something that takes into account
pagination, either service.query_everything_in_batches().each or
initializing the collection in a way that it knows how to get the next
batch.

This closes #127, mostly.
