### PR TITLE
add query_in_batches

### DIFF
--- a/lib/quickbooks/service/service_crud.rb
+++ b/lib/quickbooks/service/service_crud.rb
@@ -6,6 +6,16 @@ module Quickbooks
         fetch_collection(object_query, model, options)
       end
 
+      def query_in_batches(object_query=nil, options={})
+        page = 0
+        per_page = options.delete(:per_page) || 1_000
+        begin
+          page += 1
+          results = query(object_query, page: page, per_page: per_page)
+          yield results if results.count > 0
+        end until results.count < per_page
+      end
+
       def fetch_by_id(id, options = {})
         url = "#{url_for_resource(model.resource_for_singular)}/#{id}"
         fetch_object(model, url, options)

--- a/spec/lib/quickbooks/service/service_crud_spec.rb
+++ b/spec/lib/quickbooks/service/service_crud_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+class ServicedClass
+  extend Quickbooks::Service::ServiceCrud
+end
+
+module Quickbooks
+  module Service
+    describe ServiceCrud do
+
+      it 'defaults to 1000 per batch' do
+        ServicedClass.should_receive(:query).with(nil, page: 1, per_page: 1000).and_return(double(Quickbooks::Collection, count: 1))
+        ServicedClass.query_in_batches {}
+      end
+
+      it 'enables a custom page size option' do
+        ServicedClass.should_receive(:query).with(nil, page: 1, per_page: 10).and_return(double(Quickbooks::Collection, count: 1))
+        ServicedClass.query_in_batches(nil, per_page: 10) {}
+      end
+
+      it 'finds all the batches' do
+        ServicedClass.should_receive(:query).with(nil, page: 1, per_page: 1000).exactly(:once).and_return(double(Quickbooks::Collection, count: 1000))
+        ServicedClass.should_receive(:query).with(nil, page: 2, per_page: 1000).exactly(:once).and_return(double(Quickbooks::Collection, count: 1))
+        ServicedClass.query_in_batches {}
+      end
+
+      it 'yield the results of the query method' do
+        results = double(Quickbooks::Collection, count: 1)
+        ServicedClass.should_receive(:query).with(nil, page: 1, per_page: 1000).and_return(results)
+        ServicedClass.query_in_batches { |batch| expect(batch).to eq results }
+      end
+
+      it 'does not yield results with 0 count' do
+        yielded = []
+        ServicedClass.should_receive(:query).with(nil, page: 1, per_page: 1000).exactly(:once).and_return(double(Quickbooks::Collection, count: 1000))
+        ServicedClass.should_receive(:query).with(nil, page: 2, per_page: 1000).exactly(:once).and_return(double(Quickbooks::Collection, count: 0))
+        ServicedClass.query_in_batches { |batch| yielded << batch }
+        expect(yielded.size).to eq 1
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
This implements the `query_in_batches` feature discussed in https://github.com/ruckus/quickbooks-ruby/issues/131.
