### PR TITLE
EmployeeNumber can be a string

### DIFF
--- a/lib/quickbooks/model/employee.rb
+++ b/lib/quickbooks/model/employee.rb
@@ -27,7 +27,7 @@ module Quickbooks
       xml_accessor :primary_phone, :from => 'PrimaryPhone', :as => TelephoneNumber
       xml_accessor :mobile_phone, :from => 'Mobile', :as => TelephoneNumber
       xml_accessor :primary_email_address, :from => 'PrimaryEmailAddr', :as => EmailAddress
-      xml_accessor :number, :from => 'EmployeeNumber', :as => Integer
+      xml_accessor :number, :from => 'EmployeeNumber'
       xml_accessor :ssn, :from => 'SSN'
       xml_accessor :address, :from => 'PrimaryAddr', :as => PhysicalAddress
       xml_accessor :billable?, :from => 'BillableTime'


### PR DESCRIPTION
Just had a customer hit this.  See https://developer.intuit.com/docs/0025_quickbooksapi/0050_data_services/030_entity_services_reference/employee for reference.
