### PR TITLE
Better handling of IN queries in the query builder.

### DIFF
--- a/lib/quickbooks/util/query_builder.rb
+++ b/lib/quickbooks/util/query_builder.rb
@@ -15,12 +15,19 @@ module Quickbooks
                   value.iso8601
                 when Date
                   value.strftime('%Y-%m-%d')
+                when Array
+                  value = value.map{|v| v.to_s.gsub("'", "\\\\'") }
                 else
                   # escape single quotes with an escaped backslash
                   value = value.gsub("'", "\\\\'")
                 end
 
-        "#{field} #{operator} #{VALUE_QUOTE}#{value}#{VALUE_QUOTE}"
+        if operator.downcase == 'in' && value.is_a?(Array)
+          value = value.map{|v| "#{VALUE_QUOTE}#{v}#{VALUE_QUOTE}"}
+          "#{field} #{operator} (#{value.join(', ')})"
+        else
+          "#{field} #{operator} #{VALUE_QUOTE}#{value}#{VALUE_QUOTE}"
+        end
       end
 
     end

--- a/spec/lib/quickbooks/util/query_builder_spec.rb
+++ b/spec/lib/quickbooks/util/query_builder_spec.rb
@@ -18,4 +18,11 @@ describe Quickbooks::Util::QueryBuilder do
     generated = subject.clause("DueDate", ">", date)
     expected.should == generated
   end
+
+  it "parses an IN query with an array of values" do
+    values = [10, 20, "something", "40", "it's a quote!"]
+    expected = "DocNumber IN ('10', '20', 'something', '40', 'it\\'s a quote!')"
+    generated = subject.clause("DocNumber", "IN", values)
+    expected.should == generated
+  end
 end


### PR DESCRIPTION
Now you can pass an array of values to the query builder when specifying an "IN" operator. Automatically escapes quotes and puts it in the correct format.

Example:

``` ruby
numbers = %w(1234 4321 5678 8765)
util = Quickbooks::Util::QueryBuilder.new
clause = util.clause("DocNumber", "IN", numbers)
query = "SELECT * FROM Invoice WHERE #{clause}"

# query
# SELECT * FROM Invoice WHERE DocNumber IN ('1234', '4321', '5678', '8765')
```

With passing test that also checks for single quotes.
