### PR TITLE
ActiveRecord is not allowing :tax_applicable_on to set a string but is

### DIFF
--- a/lib/quickbooks/model/journal_entry_line_detail.rb
+++ b/lib/quickbooks/model/journal_entry_line_detail.rb
@@ -11,6 +11,9 @@ module Quickbooks
 
       xml_accessor :tax_code_ref, :from => 'TaxCodeRef', :as => BaseReference
       xml_accessor :tax_applicable_on, :from => 'TaxApplicableOn'
+      # ActiveRecord will override :tax_applicable_on so
+      # provide an alternative xml_accessor, :tax_applicable
+      xml_accessor :tax_applicable, :from => 'TaxApplicableOn'
       xml_accessor :tax_amount, :from => 'TaxAmount', :as => BigDecimal, :to_xml => to_xml_big_decimal
 
       xml_accessor :billable_status, :from => 'BillableStatus'

--- a/lib/quickbooks/util/name_entity.rb
+++ b/lib/quickbooks/util/name_entity.rb
@@ -55,10 +55,13 @@ module NameEntity
     def journal_line_entry_tax
       if tax_code_ref
         # tax_applicable_on must be set
-        errors.add(:tax_applicable_on, "TaxApplicableOn must be set when TaxCodeRef is set") if tax_applicable_on.nil?
+        if tax_applicable.nil? && tax_applicable_on.nil?
+          errors.add(:tax_applicable_on, "TaxApplicableOn must be set when TaxCodeRef is set")
+        end
         errors.add(:tax_amount, "TaxAmount must be set when TaxCodeRef is set") if tax_amount.nil?
       end
     end
+
   end
 
   module PermitAlterations

--- a/spec/lib/quickbooks/model/journal_entry_spec.rb
+++ b/spec/lib/quickbooks/model/journal_entry_spec.rb
@@ -12,7 +12,7 @@ describe "Quickbooks::Model::JournalEntry" do
     jel = Quickbooks::Model::JournalEntryLineDetail.new  
     jel.posting_type = 'Credit'
     jel.tax_code_id = 2
-    jel.tax_applicable_on = 'Credit'
+    jel.tax_applicable_on = 'Purchased'
     jel.account_id = 1
     line_item.journal_entry_line_detail = jel
     je.line_items << line_item
@@ -20,5 +20,16 @@ describe "Quickbooks::Model::JournalEntry" do
     n.at_css('JournalEntry > Line > Description').content.should == 'Received Payment'
     n.at_css('Line > JournalEntryLineDetail > TaxCodeRef').content.should == '2'
     je.valid?.should be_true
+  end
+
+  it "can support either :tax_applicable_on or :tax_applicable" do
+    jel = Quickbooks::Model::JournalEntryLineDetail.new
+    jel.stub(:description).and_return('Desc 1') # There is not xml_accessor for description on JournalEntryLineDetail?
+    jel.posting_type = 'Credit'
+    jel.tax_code_id = 2
+    jel.tax_applicable_on = nil
+    jel.tax_applicable = 'Purchased'
+    jel.account_id = 1
+    jel.errors.messages.include?(:tax_applicable_on).should be_false
   end
 end


### PR DESCRIPTION
demanding a date.

Error parsing XML: tax_applicable_on: invalid date for class
Quickbooks::Model::JournalEntryLineDetail

Most likely AR is overriding '_on' suffix setters. Provide an
alternate xml_accessor :tax_applicable for these cases but I didn't
research in depth.

Also see:
https://intuitpartnerplatform.lc.intuit.com/questions/980169-i-got-this-error-when-trying-to-add-tax_applicable_on-field-i-set-the-above-filed-to-credit-but-it-says-its-some-date-class

cc: @markrickert 
