### PR TITLE
replaced placed_on with txn_date

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ puts created_invoice.id
 #Invoices, SalesReceipts etc can also be defined in a single command
 salesreceipt = Quickbooks::Model::SalesReceipt.new({
   customer_id: 99,
-  placed_on: Date.civil(2013, 11, 20),
+  txn_date: Date.civil(2013, 11, 20),
   payment_ref_number: "111", #optional payment reference number/string - e.g. stripe token
   deposit_to_account_id: 222, #The ID of the Account entity you want the SalesReciept to be deposited to
   payment_method_id: 333 #The ID of the PaymentMethod entity you want to be used for this transaction

--- a/lib/quickbooks/model/credit_memo.rb
+++ b/lib/quickbooks/model/credit_memo.rb
@@ -11,9 +11,7 @@ module Quickbooks
       xml_accessor :meta_data, :from => 'MetaData', :as => MetaData
       xml_accessor :auto_doc_number, :from => 'AutoDocNumber' # See auto_doc_number! method below for usage
       xml_accessor :doc_number, :from => 'DocNumber'
-      #xml_accessor :txn_date, :from => 'TxnDate', :as => Date
-      # TODO: Next major version 'placed_on' should be replaced by 'txn_date'
-      xml_accessor :placed_on, :from => 'TxnDate', :as => Date
+      xml_accessor :txn_date, :from => 'TxnDate', :as => Date
       xml_accessor :department_ref, :from => 'DepartmentRef', :as => BaseReference
 
       xml_accessor :line_items, :from => 'Line', :as => [Line]
@@ -30,6 +28,9 @@ module Quickbooks
 
       # readonly
       xml_accessor :total, :from => 'TotalAmt', :as => BigDecimal
+
+      # backward-compatible alias
+      alias_attribute :placed_on, :txn_date
 
       validate :line_item_size
       validate :document_numbering

--- a/lib/quickbooks/model/refund_receipt.rb
+++ b/lib/quickbooks/model/refund_receipt.rb
@@ -10,7 +10,6 @@ module Quickbooks
       xml_accessor :meta_data, :from => 'MetaData', :as => MetaData
       xml_accessor :auto_doc_number, :from => 'AutoDocNumber' # See auto_doc_number! method below for usage
       xml_accessor :doc_number, :from => 'DocNumber'
-      xml_accessor :placed_on, :from => 'TxnDate', :as => Time
       xml_accessor :line_items, :from => 'Line', :as => [Line]
       xml_accessor :customer_ref, :from => 'CustomerRef', :as => BaseReference
       xml_accessor :department_ref, :from => 'DepartmentRef', :as => BaseReference
@@ -38,6 +37,9 @@ module Quickbooks
       # readonly
       xml_accessor :total, :from => 'TotalAmt', :as => BigDecimal
       xml_accessor :home_total, :from => 'HomeTotalAmt', :as => BigDecimal, :to_xml => to_xml_big_decimal
+
+      # backward-compatible alias
+      alias_attribute :placed_on, :txn_date
 
       include DocumentNumbering
       reference_setters :customer_ref, :payment_method_ref, :deposit_to_account_ref, :department_ref, :currency_ref, :class_ref

--- a/lib/quickbooks/model/sales_receipt.rb
+++ b/lib/quickbooks/model/sales_receipt.rb
@@ -11,7 +11,7 @@ module Quickbooks
       xml_accessor :meta_data, :from => 'MetaData', :as => MetaData
       xml_accessor :auto_doc_number, :from => 'AutoDocNumber' # See auto_doc_number! method below for usage
       xml_accessor :doc_number, :from => 'DocNumber'
-      xml_accessor :placed_on, :from => 'TxnDate', :as => Time
+      xml_accessor :txn_date, :from => 'TxnDate', :as => Time
       xml_accessor :line_items, :from => 'Line', :as => [Line]
       xml_accessor :customer_ref, :from => 'CustomerRef', :as => BaseReference
       xml_accessor :bill_email, :from => 'BillEmail', :as => EmailAddress
@@ -29,6 +29,9 @@ module Quickbooks
 
       # readonly
       xml_accessor :total, :from => 'TotalAmt', :as => BigDecimal
+
+      # backward-compatible alias
+      alias_attribute :placed_on, :txn_date
 
       reference_setters :customer_ref, :payment_method_ref, :deposit_to_account_ref
 

--- a/spec/lib/quickbooks/model/credit_memo_spec.rb
+++ b/spec/lib/quickbooks/model/credit_memo_spec.rb
@@ -18,7 +18,7 @@ describe "Quickbooks::Model::CreditMemo" do
   it "should set the transaction date" do
     credit_memo = Quickbooks::Model::CreditMemo.new
     current = Time.now
-    credit_memo.placed_on = current
+    credit_memo.txn_date = current
     credit_memo.to_xml.to_s.should =~ /TxnDate.*#{current.to_s[0..-6]}/ # shave off utc offset as Travis doesn't like
   end
 

--- a/spec/lib/quickbooks/model/sales_receipt_spec.rb
+++ b/spec/lib/quickbooks/model/sales_receipt_spec.rb
@@ -10,7 +10,7 @@ describe "Quickbooks::Model::SalesReceipt" do
     sales_receipt.meta_data.last_updated_time.should == DateTime.parse("2013-12-10T05:35:42-08:00")
 
     sales_receipt.doc_number.should == "1002"
-    sales_receipt.placed_on.should == Time.parse("2013-12-10")
+    sales_receipt.txn_date.should == Time.parse("2013-12-10")
 
     sales_receipt.line_items.first.should_not be_nil
     sales_receipt.line_items.first.id.should == 1

--- a/spec/lib/quickbooks/service/credit_memo_spec.rb
+++ b/spec/lib/quickbooks/service/credit_memo_spec.rb
@@ -39,7 +39,7 @@ module Quickbooks
         credit_memo.doc_number = "R3454653464"
         credit_memo.customer_id = 2
         credit_memo.payment_method_id = 1
-        credit_memo.placed_on = Time.now
+        credit_memo.txn_date = Time.now
         credit_memo.line_items = [line]
 
         credit_memo = subject.create(credit_memo)

--- a/spec/lib/quickbooks/service/refund_receipt_spec.rb
+++ b/spec/lib/quickbooks/service/refund_receipt_spec.rb
@@ -48,7 +48,7 @@ module Quickbooks
         receipt = model.new
         receipt.customer_id = 2
         receipt.deposit_to_account_id = 2
-        receipt.placed_on = Time.now
+        receipt.txn_date = Time.now
         receipt.line_items = [line]
 
         receipt = subject.create(receipt)

--- a/spec/lib/quickbooks/service/sales_receipt_spec.rb
+++ b/spec/lib/quickbooks/service/sales_receipt_spec.rb
@@ -48,7 +48,7 @@ module Quickbooks
         receipt = model.new
         receipt.customer_id = 2
         receipt.ship_method_ref = "Ship Method"
-        receipt.placed_on = Time.now
+        receipt.txn_date = Time.now
         receipt.line_items = [line]
 
         receipt = subject.create(receipt)


### PR DESCRIPTION
`placed_on` is no longer documented by the API. It should be upgraded to use `txn_date`. Yet the gem should still support `placed_on` that is alias with `txn_date`.
