### PR TITLE
Added Fault#detail

### DIFF
--- a/lib/quickbooks/model/fault.rb
+++ b/lib/quickbooks/model/fault.rb
@@ -6,6 +6,7 @@ module Quickbooks
         xml_name 'Error'
         xml_accessor :code, :from => "@code"
         xml_accessor :message, :from => "Message"
+        xml_accessor :detail, :from => "Detail"
       end
 
       xml_accessor :errors, :as => [Quickbooks::Model::Fault::Error]

--- a/spec/fixtures/batch_response.xml
+++ b/spec/fixtures/batch_response.xml
@@ -2,11 +2,13 @@
 <IntuitResponse xmlns="http://schema.intuit.com/finance/v3" time="2014-02-03T03:48:58.191-08:00">
   <BatchItemResponse bId="1a">
     <Fault type="ValidationFault">
-      <Error code="101">
-        <Message>Length of the field exceeds 21 chars </Message>
+      <Error code="2050" element="firstname">
+        <Message>Length exceeds limit</Message>
+        <Detail>Length of the field exceeds 21 chars</Detail>
       </Error>
-      <Error code="201">
-        <Message>ZipCode should be a number with at least 5 digits</Message>
+      <Error code="2080" element="postalcode">
+        <Message>Illegal number format</Message>
+        <Detail>ZipCode should be a number with at least 5 digits</Detail>
       </Error>
     </Fault>
   </BatchItemResponse>

--- a/spec/fixtures/fault.xml
+++ b/spec/fixtures/fault.xml
@@ -1,8 +1,10 @@
 <Fault type="ValidationFault">
-  <Error code="101">
-    <Message>Length of the field exceeds 21 chars</Message>
+  <Error code="2050" element="firstname">
+    <Message>Length exceeds limit</Message>
+    <Detail>Length of the field exceeds 21 chars</Detail>
   </Error>
-  <Error code="201">
-    <Message>ZipCode should be a number with at least 5 digits</Message>
+  <Error code="2080" element="postalcode">
+    <Message>Illegal number format</Message>
+    <Detail>ZipCode should be a number with at least 5 digits</Detail>
   </Error>
 </Fault>

--- a/spec/lib/quickbooks/model/fault_spec.rb
+++ b/spec/lib/quickbooks/model/fault_spec.rb
@@ -6,11 +6,12 @@ describe Quickbooks::Model::Fault do
     fault = Quickbooks::Model::Fault.from_xml(fault_xml)
     fault.errors.size.should == 2
     first_error = fault.errors.first
-    first_error.code.should == "101"
-    first_error.message.should == "Length of the field exceeds 21 chars"
-
+    first_error.code.should == "2050"
+    first_error.message.should == "Length exceeds limit"
+    first_error.detail.should == "Length of the field exceeds 21 chars"
     last_error = fault.errors.last
-    last_error.code.should == "201"
-    last_error.message.should == "ZipCode should be a number with at least 5 digits"
+    last_error.code.should == "2080"
+    last_error.message.should == "Illegal number format"
+    last_error.detail.should == "ZipCode should be a number with at least 5 digits"
   end
 end


### PR DESCRIPTION
`Fault` should return the detail field from QBO. The spec is updated with the xml sample on https://developer.intuit.com/docs/0025_quickbooksapi/0050_data_services/050_errors/0040_fault_element.
