### PR TITLE
handle nil class error for linked_transaction in line.rb #168

### DIFF
--- a/lib/quickbooks/model/line.rb
+++ b/lib/quickbooks/model/line.rb
@@ -23,8 +23,8 @@ module Quickbooks
       xml_accessor :journal_entry_line_detail, :from => 'JournalEntryLineDetail', :as => JournalEntryLineDetail
 
       def initialize(*args)
-        super
         self.linked_transactions ||= []
+        super
       end
 
       def invoice_id=(id)


### PR DESCRIPTION
calling  `super` before assigning value [] to `self.linked_transactions` is causing exception.

`super` calls `remove_linked_transactions` method which tries to delete previous `linked_transactions`. As `linked_transaction`  is not initialized yet so it generates 
`NoMethodError: undefined method 'delete_if' for nil:NilClass'` exception. Initializing `linked_transaction` before `super` has fixed this exception
