### PR TITLE
Add exchange_rate and home_total_amount to the invoice model

### DIFF
--- a/lib/quickbooks/model/invoice.rb
+++ b/lib/quickbooks/model/invoice.rb
@@ -23,6 +23,7 @@ module Quickbooks
       xml_accessor :doc_number, :from => 'DocNumber'
       xml_accessor :txn_date, :from => 'TxnDate', :as => Date
       xml_accessor :currency_ref, :from => 'CurrencyRef', :as => BaseReference
+      xml_accessor :exchange_rate, :from => 'ExchangeRate', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :private_note, :from => 'PrivateNote'
       xml_accessor :linked_transactions, :from => 'LinkedTxn', :as => [LinkedTransaction]
       xml_accessor :line_items, :from => 'Line', :as => [InvoiceLineItem]
@@ -39,6 +40,7 @@ module Quickbooks
       xml_accessor :tracking_num, :from => 'TrackingNum'
       xml_accessor :ar_account_ref, :from => 'ARAccountRef', :as => BaseReference
       xml_accessor :total_amount, :from => 'TotalAmt', :as => BigDecimal, :to_xml => to_xml_big_decimal
+      xml_accessor :home_total_amount, :from => 'HomeTotalAmt', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :apply_tax_after_discount?, :from => 'ApplyTaxAfterDiscount'
       xml_accessor :print_status, :from => 'PrintStatus'
       xml_accessor :email_status, :from => 'EmailStatus'

--- a/spec/fixtures/invoice.xml
+++ b/spec/fixtures/invoice.xml
@@ -8,6 +8,7 @@
 	<DocNumber>1001</DocNumber>
 	<TxnDate>2013-11-15</TxnDate>
 	<CurrencyRef name="United States Dollar">USD</CurrencyRef>
+	<ExchangeRate>1.5</ExchangeRate> <!-- Present for non-USA accounts -->
 	<PrivateNote>Statement Memo</PrivateNote>
 	<Line>
 		<Id>1</Id>
@@ -74,6 +75,7 @@
 	<SalesTermRef>2</SalesTermRef>
 	<DueDate>2013-11-30</DueDate>
 	<TotalAmt>50.00</TotalAmt>
+	<HomeTotalAmt>75.00</HomtTotalAmt> <!-- Present for non-USA accounts -->
 	<ApplyTaxAfterDiscount>false</ApplyTaxAfterDiscount>
 	<PrintStatus>NotSet</PrintStatus>
 	<EmailStatus>NotSet</EmailStatus>

--- a/spec/lib/quickbooks/model/invoice_spec.rb
+++ b/spec/lib/quickbooks/model/invoice_spec.rb
@@ -15,6 +15,7 @@ describe "Quickbooks::Model::Invoice" do
     invoice.line_items.length.should == 2
     invoice.currency_ref.to_s.should == 'USD'
     invoice.currency_ref.name.should == 'United States Dollar'
+    invoice.exchange_rate.should == 1.5
 
     line_item1 = invoice.line_items[0]
     line_item1.id.should == 1
@@ -77,6 +78,7 @@ describe "Quickbooks::Model::Invoice" do
     invoice.sales_term_ref.to_i.should == 2
     invoice.due_date.to_date.should == Date.civil(2013, 11, 30)
     invoice.total_amount.should == 50.00
+    invoice.home_total_amount.should == 75.00
     invoice.apply_tax_after_discount?.should == false
     invoice.print_status.should == 'NotSet'
     invoice.email_status.should == 'NotSet'


### PR DESCRIPTION
These fields are only present in invoices from non-USA QB accounts, [invoice reference here](https://developer.intuit.com/docs/0025_quickbooksapi/0050_data_services/030_entity_services_reference/invoice).
