### PR TITLE
Support sandbox mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ Gems:
 * `nokogiri` : XML parsing
 * `active_model` : For validations
 
+## Sandbox Mode
+An API app provides two sets of OAuth key for production and development. Since October 22, 2014, only [Sandbox Companies](https://developer.intuit.com/docs/0025_quickbooksapi/0050_data_services)
+are allowed to connected to the QBO via the development key. The end-point for sandbox mode is https://sandbox-quickbooks.api.intuit.com.
+
+By default, the gem runs in production mode. If you prefer to develop / test the integration with the development key,
+you need to config the gem to run in sandbox mode:
+
+```ruby
+Quickbooks.sandbox_mode = true
+```
+
 ## Getting Started & Initiating Authentication Flow with Intuit
 
 What follows is an example using Rails but the principles can be adapted to any other framework / pure Ruby.

--- a/lib/quickbooks-ruby.rb
+++ b/lib/quickbooks-ruby.rb
@@ -117,9 +117,19 @@ require 'quickbooks/service/preferences'
 require 'quickbooks/service/refund_receipt'
 
 module Quickbooks
+  @@sandbox_mode = false
+
   @@logger = nil
 
   class << self
+    def sandbox_mode
+      @@sandbox_mode
+    end
+
+    def sandbox_mode=(sandbox_mode)
+      @@sandbox_mode = sandbox_mode
+    end
+
     def logger
       @@logger ||= ::Logger.new($stdout) # TODO: replace with a real log file
     end

--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -15,9 +15,11 @@ module Quickbooks
       HTTP_ACCEPT = 'application/xml'
       HTTP_ACCEPT_ENCODING = 'gzip, deflate'
       BASE_DOMAIN = 'quickbooks.api.intuit.com'
+      SANDBOX_DOMAIN = 'sandbox-quickbooks.api.intuit.com'
 
       def initialize(attributes = {})
-        @base_uri = "https://#{BASE_DOMAIN}/v3/company"
+        domain = Quickbooks.sandbox_mode ? SANDBOX_DOMAIN : BASE_DOMAIN
+        @base_uri = "https://#{domain}/v3/company"
         attributes.each {|key, value| public_send("#{key}=", value) }
       end
 


### PR DESCRIPTION
The IPP App token is changed today. Development API key only allows connections with the sandbox accounts. The commit allows to config to run in sandbox mode with a different endpoint. 

Ref: https://developer.intuit.com/v2/blog/2014/10/20/changes-to-ipp-app-tokens
