### PR TITLE
Throw ServiceUnavailable for HTTP 504s as well as HTTP 503s

### DIFF
--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -250,7 +250,7 @@ module Quickbooks
           raise Quickbooks::AuthorizationFailure
         when 400, 500
           parse_and_raise_exception(options)
-        when 503
+        when 503, 504
           raise Quickbooks::ServiceUnavailable
         else
           raise "HTTP Error Code: #{status}, Msg: #{response.plain_body}"

--- a/spec/lib/quickbooks/service/base_service_spec.rb
+++ b/spec/lib/quickbooks/service/base_service_spec.rb
@@ -61,6 +61,16 @@ describe Quickbooks::Service::BaseService do
         ex.request_xml.should == xml2
       end
     end
+
+    it "should raise ServiceUnavailable on HTTP 503 and 504" do
+      xml = fixture('generic_error.xml')
+
+      response = Struct.new(:code, :plain_body).new(503, xml)
+      expect { @service.send(:check_response, response) }.to raise_error(Quickbooks::ServiceUnavailable)
+
+      response = Struct.new(:code, :plain_body).new(504, xml)
+      expect { @service.send(:check_response, response) }.to raise_error(Quickbooks::ServiceUnavailable)
+    end
   end
 
   it "Correctly handled an IntuitRequestException" do


### PR DESCRIPTION
Hi there again @ruckus ! We came across this response from QBO and it looks like `Quickbooks::ServiceUnavailable` should fit the bill.

```
HTTP Error Code: 504, Msg:
<IntuitResponse xmlns="http://schema.intuit.com/finance/v3" time="2014-10-23T17:13:11.934Z" requestId="ae04144172874bf488486d1874c364d1">
    <Fault type="SERVICE">
        <Error code="6002">
            <Message>message=Timeout occurred while proxying request; errorCode=006002; statusCode=504</Message>
        </Error>
    </Fault>
</IntuitResponse>
```

This PR also adds some test coverage for HTTP 503s. Thanks!
