### PR TITLE
Invalid xml responses

### DIFF
--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -269,6 +269,8 @@ module Quickbooks
 
       def response_is_error?
         @last_response_xml.xpath("//xmlns:IntuitResponse/xmlns:Fault")[0] != nil
+      rescue Nokogiri::XML::XPath::SyntaxError => exception
+        true
       end
 
       def parse_intuit_error
@@ -287,6 +289,10 @@ module Quickbooks
             error[:detail] = error_element.xpath("//xmlns:Detail").text
           end
         end
+
+        error
+      rescue Nokogiri::XML::XPath::SyntaxError => exception
+        error[:detail] = @last_response_xml.to_s
 
         error
       end

--- a/spec/lib/quickbooks/service/base_service_spec.rb
+++ b/spec/lib/quickbooks/service/base_service_spec.rb
@@ -71,6 +71,28 @@ describe Quickbooks::Service::BaseService do
       response = Struct.new(:code, :plain_body).new(504, xml)
       expect { @service.send(:check_response, response) }.to raise_error(Quickbooks::ServiceUnavailable)
     end
+
+    it "handles error XML with a missing namespace" do
+      xml = <<-XML
+<?xml version=\"1.0\"?>
+<IntuitResponse time="2013-11-15T13:16:49.528-08:00">
+  <Fault type="SystemFault">
+    <Error code="10000">
+      <Message>An application error has occurred while processing your request</Message>
+      <Detail>System Failure Error: Could not find resource for relative : some more info here</Detail>
+    </Error>
+  </Fault>
+</IntuitResponse>
+      XML
+      response = Struct.new(:code, :plain_body).new(200, xml)
+
+      begin
+        @service.send :check_response, response
+        fail "Exception expected"
+      rescue Quickbooks::IntuitRequestException => exception
+        expect(exception.detail).to eq(xml)
+      end
+    end
   end
 
   it "Correctly handled an IntuitRequestException" do


### PR DESCRIPTION
Raise a `Quickbooks:: IntuitRequestException` exception instead of a Nokogiri exception when a namespace is missing. Before this request, we were seeing `Nokogiri::XML::XPath::SyntaxError` exceptions.
