### PR TITLE
Added Quickbooks::Forbidden for HTTP 403

### DIFF
--- a/lib/quickbooks-ruby.rb
+++ b/lib/quickbooks-ruby.rb
@@ -162,6 +162,7 @@ module Quickbooks
   class InvalidModelException < StandardError; end
 
   class AuthorizationFailure < StandardError; end
+  class Forbidden < StandardError; end
 
   class ServiceUnavailable < StandardError; end
   class MissingRealmError < StandardError; end

--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -246,8 +246,10 @@ module Quickbooks
           end
         when 302
           raise "Unhandled HTTP Redirect"
-        when 401, 403
+        when 401
           raise Quickbooks::AuthorizationFailure
+        when 403
+          raise Quickbooks::Forbidden
         when 400, 500
           parse_and_raise_exception(options)
         when 503, 504

--- a/spec/lib/quickbooks/service/base_service_spec.rb
+++ b/spec/lib/quickbooks/service/base_service_spec.rb
@@ -62,6 +62,20 @@ describe Quickbooks::Service::BaseService do
       end
     end
 
+    it "should raise AuthorizationFailure on HTTP 401" do
+      xml = fixture('generic_error.xml')
+
+      response = Struct.new(:code, :plain_body).new(401, xml)
+      expect { @service.send(:check_response, response) }.to raise_error(Quickbooks::AuthorizationFailure)
+    end
+
+    it "should raise Forbidden on HTTP 403" do
+      xml = fixture('generic_error.xml')
+
+      response = Struct.new(:code, :plain_body).new(403, xml)
+      expect { @service.send(:check_response, response) }.to raise_error(Quickbooks::Forbidden)
+    end
+
     it "should raise ServiceUnavailable on HTTP 503 and 504" do
       xml = fixture('generic_error.xml')
 


### PR DESCRIPTION
This commit may be _controversial_ as it introduced a new class of `StandardError` to handle 403 error. It is necessary to treat 401 and 403 differently - 403 error happens when the users do not have the permissions to access some resources; whereas 401 error happens when the token is expired or reverted. In the business logic, the error handlers of 401 and 403 could be drastically different.
