### PR TITLE
Make the API for total amounts consistent

### DIFF
--- a/lib/quickbooks/model/estimate.rb
+++ b/lib/quickbooks/model/estimate.rb
@@ -35,7 +35,7 @@ module Quickbooks
       xml_accessor :shipping_address, :from => 'ShipAddr', :as => PhysicalAddress
       xml_accessor :class_ref, :from => 'ClassRef', :as => BaseReference
       xml_accessor :sales_term_ref, :from => 'SalesTermRef', :as => BaseReference
-      xml_accessor :total_amount, :from => 'TotalAmt', :as => BigDecimal, :to_xml => to_xml_big_decimal
+      xml_accessor :total, :from => 'TotalAmt', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :ship_method_ref, :from => 'ShipMethodRef', :as => BaseReference
       xml_accessor :ship_date, :from => 'ShipDate', :as => Date
 
@@ -48,6 +48,10 @@ module Quickbooks
       xml_accessor :accepted_date, :from => 'AcceptedDate', :as => Date
 
       reference_setters :department_ref, :customer_ref, :class_ref, :sales_term_ref, :ship_method_ref
+
+      #== This adds aliases for backwards compatability to old attributes names
+      alias_method :total_amount, :total
+      alias_method :total_amount=, :total=
 
       #== Validations
       validate :line_item_size

--- a/lib/quickbooks/model/invoice.rb
+++ b/lib/quickbooks/model/invoice.rb
@@ -41,8 +41,8 @@ module Quickbooks
       xml_accessor :ship_date, :from => 'ShipDate', :as => Date
       xml_accessor :tracking_num, :from => 'TrackingNum'
       xml_accessor :ar_account_ref, :from => 'ARAccountRef', :as => BaseReference
-      xml_accessor :total_amount, :from => 'TotalAmt', :as => BigDecimal, :to_xml => to_xml_big_decimal
-      xml_accessor :home_total_amount, :from => 'HomeTotalAmt', :as => BigDecimal, :to_xml => to_xml_big_decimal
+      xml_accessor :total, :from => 'TotalAmt', :as => BigDecimal, :to_xml => to_xml_big_decimal
+      xml_accessor :home_total, :from => 'HomeTotalAmt', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :apply_tax_after_discount?, :from => 'ApplyTaxAfterDiscount'
       xml_accessor :print_status, :from => 'PrintStatus'
       xml_accessor :email_status, :from => 'EmailStatus'
@@ -57,6 +57,12 @@ module Quickbooks
 
       reference_setters :customer_ref, :class_ref, :sales_term_ref, :ship_method_ref
       reference_setters :ar_account_ref, :department_ref, :ar_account_ref, :currency_ref
+
+      #== This adds aliases for backwards compatability to old attributes names
+      alias_method :total_amount, :total
+      alias_method :total_amount=, :total=
+      alias_method :home_total_amount, :home_total
+      alias_method :home_total_amount=, :home_total=
 
       #== Validations
       validate :line_item_size

--- a/lib/quickbooks/model/journal_entry.rb
+++ b/lib/quickbooks/model/journal_entry.rb
@@ -17,8 +17,12 @@ module Quickbooks
 
       # Readonly
       xml_accessor :currency_ref, :from => 'CurrencyRef', :as => BaseReference
-      xml_accessor :total_amount, :from => 'TotalAmt', :as => BigDecimal, :to_xml => to_xml_big_decimal
+      xml_accessor :total, :from => 'TotalAmt', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :home_total, :from => 'HomeTotalAmt', :as => BigDecimal, :to_xml => to_xml_big_decimal
+
+      #== This adds aliases for backwards compatability to old attributes names
+      alias_method :total_amount, :total
+      alias_method :total_amount=, :total=
 
       xml_accessor :adjustment?, :from => 'Adjustment'
 

--- a/lib/quickbooks/model/purchase.rb
+++ b/lib/quickbooks/model/purchase.rb
@@ -33,11 +33,15 @@ module Quickbooks
       xml_accessor :payment_type, :from => 'PaymentType'
       xml_accessor :entity_ref, :from => 'EntityRef', :as => BaseReference
       xml_accessor :remit_to_address, :from => 'RemitToAddr', :as => PhysicalAddress
-      xml_accessor :total_amount, :from => 'TotalAmt', :as => BigDecimal, :to_xml => to_xml_big_decimal
+      xml_accessor :total, :from => 'TotalAmt', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :print_status, :from => 'PrintStatus'
       xml_accessor :department_ref, :from => 'DepartmentRef', :as => BaseReference
 
       reference_setters :account_ref, :entity_ref, :department_ref
+
+      #== This adds aliases for backwards compatability to old attributes names
+      alias_method :total_amount, :total
+      alias_method :total_amount=, :total=
 
     end
   end

--- a/lib/quickbooks/model/purchase_order.rb
+++ b/lib/quickbooks/model/purchase_order.rb
@@ -25,7 +25,7 @@ module Quickbooks
       xml_accessor :class_ref, :from => 'ClassRef', :as => BaseReference
       xml_accessor :sales_term_ref, :from => 'SalesTermRef', :as => BaseReference
 
-      xml_accessor :total_amount, :from => 'TotalAmt', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
+      xml_accessor :total, :from => 'TotalAmt', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
       xml_accessor :due_date, :from => 'DueDate', :as => Date
       xml_accessor :vendor_address, :from => 'VendorAddr', :as => PhysicalAddress
       xml_accessor :ship_address, :from => 'ShipAddr', :as => PhysicalAddress
@@ -34,6 +34,10 @@ module Quickbooks
       xml_accessor :txn_tax_detail, :from => 'TxnTaxDetail', :as => TransactionTaxDetail
 
       reference_setters :attachable_ref, :vendor_ref, :ap_account_ref, :class_ref, :sales_term_ref, :ship_method_ref
+
+      #== This adds aliases for backwards compatability to old attributes names
+      alias_method :total_amount, :total
+      alias_method :total_amount=, :total=
 
     end
   end

--- a/lib/quickbooks/model/vendor_credit.rb
+++ b/lib/quickbooks/model/vendor_credit.rb
@@ -23,9 +23,13 @@ module Quickbooks
       xml_accessor :department_ref, :from => 'DepartmentRef', :as => BaseReference
       xml_accessor :ap_account_ref, :from => 'APAccountRef', :as => BaseReference
       xml_accessor :vendor_ref, :from => 'VendorRef', :as => BaseReference
-      xml_accessor :total_amount, :from => 'TotalAmt', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
+      xml_accessor :total, :from => 'TotalAmt', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
 
       reference_setters :department_ref, :ap_account_ref, :vendor_ref
+
+      #== This adds aliases for backwards compatability to old attributes names
+      alias_method :total_amount, :total
+      alias_method :total_amount=, :total=
 
     end
   end


### PR DESCRIPTION
There were inconsistent names being used for the total_amount attribute (namely total_amount vs total), as well as for the home_total_amount (home_total_amount vs home_total).

This attempts to resolve the inconsistency and create a convention (total/home_total) based on the most widely used name's on existing objects.  It also creates alias's to the previous names so the library maintains backwards compatibility.
