### PR TITLE
Removes unused options from service delete methods.

### DIFF
--- a/lib/quickbooks/service/bill.rb
+++ b/lib/quickbooks/service/bill.rb
@@ -2,7 +2,7 @@ module Quickbooks
   module Service
     class Bill < BaseService
 
-      def delete(bill, options = {})
+      def delete(bill)
         delete_by_query_string(bill)
       end
 

--- a/lib/quickbooks/service/bill_payment.rb
+++ b/lib/quickbooks/service/bill_payment.rb
@@ -2,7 +2,7 @@ module Quickbooks
   module Service
     class BillPayment < BaseService
 
-      def delete(bill_payment, options = {})
+      def delete(bill_payment)
         delete_by_query_string(bill_payment)
       end
 

--- a/lib/quickbooks/service/credit_memo.rb
+++ b/lib/quickbooks/service/credit_memo.rb
@@ -2,7 +2,7 @@ module Quickbooks
   module Service
     class CreditMemo < BaseService
 
-      def delete(credit_memo, options = {})
+      def delete(credit_memo)
         delete_by_query_string(credit_memo)
       end
 

--- a/lib/quickbooks/service/estimate.rb
+++ b/lib/quickbooks/service/estimate.rb
@@ -2,7 +2,7 @@ module Quickbooks
   module Service
     class Estimate < BaseService
 
-      def delete(estimate, options = {})
+      def delete(estimate)
         delete_by_query_string(estimate)
       end
 

--- a/lib/quickbooks/service/invoice.rb
+++ b/lib/quickbooks/service/invoice.rb
@@ -2,7 +2,7 @@ module Quickbooks
   module Service
     class Invoice < BaseService
 
-      def delete(invoice, options = {})
+      def delete(invoice)
         delete_by_query_string(invoice)
       end
 

--- a/lib/quickbooks/service/journal_entry.rb
+++ b/lib/quickbooks/service/journal_entry.rb
@@ -2,7 +2,7 @@ module Quickbooks
   module Service
     class JournalEntry < BaseService
 
-      def delete(entry, options = {})
+      def delete(entry)
         delete_by_query_string(entry)
       end
 

--- a/lib/quickbooks/service/purchase_order.rb
+++ b/lib/quickbooks/service/purchase_order.rb
@@ -2,7 +2,7 @@ module Quickbooks
   module Service
     class PurchaseOrder < BaseService
 
-      def delete(purchase_order, options = {})
+      def delete(purchase_order)
         delete_by_query_string(purchase_order)
       end
 

--- a/lib/quickbooks/service/time_activity.rb
+++ b/lib/quickbooks/service/time_activity.rb
@@ -1,9 +1,8 @@
 module Quickbooks
   module Service
     class TimeActivity < BaseService
-      include ServiceCrud
 
-      def delete(time_activity, options = {})
+      def delete(time_activity)
         delete_by_query_string(time_activity)
       end
 


### PR DESCRIPTION
This removes an unused options argument from the delete methods of services.

The options argument wasn't used by any of the services, and it makes their interface inconsistent with the base_service API.
