### PR TITLE
Allow employee_id and vendor_id helper methods to work properly.

### DIFF
--- a/lib/quickbooks/model/time_activity.rb
+++ b/lib/quickbooks/model/time_activity.rb
@@ -37,12 +37,24 @@ module Quickbooks
       xml_accessor :end_time, :from => 'EndTime', :as => DateTime
       xml_accessor :time_zone, :from => 'TimeZone'
 
-      #== Validations
-      validates_inclusion_of :name_of, :in => NAMEOF_OPTIONS
-      validates_presence_of :employee_ref, :if => Proc.new { |ta| ta.name_of == "Employee" }
-      validates_presence_of :vendor_ref, :if => Proc.new { |ta| ta.name_of == "Vendor" }
-
       reference_setters
+
+      # == Validations
+      validates_inclusion_of :name_of, :in => NAMEOF_OPTIONS
+      validate :existence_of_employee_ref, :if => Proc.new { |ta| ta.name_of == "Employee" }
+      validate :existence_of_vendor_ref, :if => Proc.new { |ta| ta.name_of == "Vendor" }
+
+      def existence_of_employee_ref
+        if employee_ref.nil? || (employee_ref && employee_ref.value == 0)
+          errors.add(:employee_ref, "VendorRef is required and must be a non-zero value.")
+        end
+      end
+
+      def existence_of_vendor_ref
+        if vendor_ref.nil? || (vendor_ref && vendor_ref.value == 0)
+          errors.add(:vendor_ref, "VendorRef is required and must be a non-zero value.")
+        end
+      end
 
       def valid_for_update?
         if sync_token.nil?


### PR DESCRIPTION
Object was being validated ahead of reference setters preventing the helper methods to be registered. 
