### PR TITLE
Namespace Validator class

### DIFF
--- a/lib/quickbooks/model/validator.rb
+++ b/lib/quickbooks/model/validator.rb
@@ -1,6 +1,10 @@
-module Validator
+module Quickbooks
+  module Model
+    module Validator
 
-  def line_item_size
-    validates_length_of :line_items, :minimum => 1, :message => 'At least 1 line item is required'
+      def line_item_size
+        validates_length_of :line_items, :minimum => 1, :message => 'At least 1 line item is required'
+      end
+    end
   end
 end


### PR DESCRIPTION
It's only used in Quickbooks::Model::BaseModel, so the including should still "just work"