### PR TITLE
 Assign EntityRef for Journal Entry to use BaseReference so that 'type' a...

### DIFF
--- a/lib/quickbooks/model/entity.rb
+++ b/lib/quickbooks/model/entity.rb
@@ -4,7 +4,7 @@ module Quickbooks
       include NameEntity::Quality
 
       xml_accessor :type, :from => 'Type'
-      xml_accessor :entity_ref, :from => 'EntityRef'
+      xml_accessor :entity_ref, :as => BaseReference
 
       reference_setters :entity_ref
 

--- a/spec/lib/quickbooks/model/journal_entry_spec.rb
+++ b/spec/lib/quickbooks/model/journal_entry_spec.rb
@@ -4,8 +4,7 @@ describe "Quickbooks::Model::JournalEntry" do
 
   it "validates basic setup" do
     je = Quickbooks::Model::JournalEntry.new
-    je.line_items = []
-    line_item             = Quickbooks::Model::Line.new
+    line_item = Quickbooks::Model::Line.new
     line_item.description = 'Received Payment'
     line_item.amount      = 148.99
     line_item.detail_type = 'JournalEntryLineDetail'
@@ -17,9 +16,27 @@ describe "Quickbooks::Model::JournalEntry" do
     line_item.journal_entry_line_detail = jel
     je.line_items << line_item
     n = Nokogiri::XML(je.to_xml.to_s)
-    n.at_css('JournalEntry > Line > Description').content.should == 'Received Payment'
-    n.at_css('Line > JournalEntryLineDetail > TaxCodeRef').content.should == '2'
+    n.at('JournalEntry > Line > Description').content.should == 'Received Payment'
+    n.at('Line > JournalEntryLineDetail > TaxCodeRef').content.should == '2'
     je.valid?.should be_true
+  end
+
+  it 'creates an entity reference' do
+    je = Quickbooks::Model::JournalEntry.new
+    line_item = Quickbooks::Model::Line.new
+    jel = Quickbooks::Model::JournalEntryLineDetail.new
+    entity = Quickbooks::Model::Entity.new
+    entity.type = 'Customer'
+    entity_ref = Quickbooks::Model::BaseReference.new(1)
+    entity_ref.name = 'James Rockenstall'
+    entity.entity_ref = entity_ref
+    jel.entity = entity
+    line_item.journal_entry_line_detail = jel
+    je.line_items << line_item
+    n = Nokogiri::XML(je.to_xml.to_s)
+    n.at('Line > JournalEntryLineDetail > Entity > Type').content.should == 'Customer'
+    n.at('JournalEntryLineDetail > Entity > EntityRef').content.should == '1'
+    n.at('JournalEntryLineDetail > Entity > EntityRef')[:name].should == 'James Rockenstall'
   end
 
   it "parse from XML" do


### PR DESCRIPTION
...nd 'name' attributes can be supported

e.g.
```
<?xml version="1.0"?>
<JournalEntry>
  <Line>
    <JournalEntryLineDetail>
      <Entity>
        <Type>Customer</Type>
        <EntityRef name="James Rockenstall">1</EntityRef>
      </Entity>
    </JournalEntryLineDetail>
  </Line>
</JournalEntry>
```