### PR TITLE
Changed the initialize method of BaseReference model

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ I say *pseudo* because they look like Integers but Intuit has made it clear they
 Anyways, its subtle but the value for a `SalesReceipt#ShipMethodRef` while it is a `BaseReference` needs to be set manually:
 
 ```ruby
-shipping_reference = Quickbooks::Model::BaseReference.new(name: 'FedEx', value: 'FedEx')
+shipping_reference = Quickbooks::Model::BaseReference.new('FedEx', name: 'FedEx')
 receipt.ship_method_ref = shipping_reference
 ```
 
@@ -498,7 +498,7 @@ meta = Quickbooks::Model::Attachable.new
 meta.file_name = "monkey.jpg"
 meta.note = "A note"
 meta.content_type = "image/jpeg"
-entity = Quickbooks::Model::BaseReference.new(type: 'Customer', value: 3)
+entity = Quickbooks::Model::BaseReference.new(3, type: 'Customer')
 meta.attachable_ref = Quickbooks::Model::AttachableRef.new(entity)
 ```
 

--- a/README.md
+++ b/README.md
@@ -302,9 +302,7 @@ I say *pseudo* because they look like Integers but Intuit has made it clear they
 Anyways, its subtle but the value for a `SalesReceipt#ShipMethodRef` while it is a `BaseReference` needs to be set manually:
 
 ```ruby
-shipping_reference = Quickbooks::Model::BaseReference.new
-shipping_reference.name = 'FedEx'
-shipping_reference.value = 'FedEx'
+shipping_reference = Quickbooks::Model::BaseReference.new(name: 'FedEx', value: 'FedEx')
 receipt.ship_method_ref = shipping_reference
 ```
 
@@ -500,9 +498,7 @@ meta = Quickbooks::Model::Attachable.new
 meta.file_name = "monkey.jpg"
 meta.note = "A note"
 meta.content_type = "image/jpeg"
-entity = Quickbooks::Model::BaseReference.new
-entity.type = 'Customer'
-entity.value = 3 # Id of the Customer
+entity = Quickbooks::Model::BaseReference.new(type: 'Customer', value: 3)
 meta.attachable_ref = Quickbooks::Model::AttachableRef.new(entity)
 ```
 

--- a/lib/quickbooks/model/base_model.rb
+++ b/lib/quickbooks/model/base_model.rb
@@ -72,7 +72,7 @@ module Quickbooks
         #   reference_setters :discount_ref
         # Would generate a method like:
         # def discount_id=(id)
-        #    self.discount_ref = BaseReference.new(value: id)
+        #    self.discount_ref = BaseReference.new(id)
         # end
         def reference_setters(*args)
           references = args.empty? ? reference_attrs : args
@@ -82,7 +82,7 @@ module Quickbooks
             unless instance_methods(false).include?(method_name)
               method_definition = <<-METH
               def #{method_name}(id)
-                self.#{attribute} = BaseReference.new(value: id)
+                self.#{attribute} = BaseReference.new(id)
               end
               METH
               class_eval(method_definition)

--- a/lib/quickbooks/model/base_model.rb
+++ b/lib/quickbooks/model/base_model.rb
@@ -72,7 +72,7 @@ module Quickbooks
         #   reference_setters :discount_ref
         # Would generate a method like:
         # def discount_id=(id)
-        #    self.discount_ref = BaseReference.new(id)
+        #    self.discount_ref = BaseReference.new(value: id)
         # end
         def reference_setters(*args)
           references = args.empty? ? reference_attrs : args
@@ -82,7 +82,7 @@ module Quickbooks
             unless instance_methods(false).include?(method_name)
               method_definition = <<-METH
               def #{method_name}(id)
-                self.#{attribute} = BaseReference.new(id)
+                self.#{attribute} = BaseReference.new(value: id)
               end
               METH
               class_eval(method_definition)

--- a/lib/quickbooks/model/base_reference.rb
+++ b/lib/quickbooks/model/base_reference.rb
@@ -6,7 +6,7 @@ module Quickbooks
       xml_accessor :value, :from => :content
       xml_accessor :type, :from => '@type' # Attribute with name 'type'
 
-      def initialize(value, attributes={})
+      def initialize(value=nil, attributes={})
         self.value = value
         attributes.each {|key, value| public_send("#{key}=", value) }
       end

--- a/lib/quickbooks/model/base_reference.rb
+++ b/lib/quickbooks/model/base_reference.rb
@@ -6,12 +6,9 @@ module Quickbooks
       xml_accessor :value, :from => :content
       xml_accessor :type, :from => '@type' # Attribute with name 'type'
 
-      def initialize(attributes={})
-        if attributes.kind_of?(Hash)
-          attributes.each {|key, value| public_send("#{key}=", value) }
-        else
-          self.value = attributes
-        end
+      def initialize(value, attributes={})
+        self.value = value
+        attributes.each {|key, value| public_send("#{key}=", value) }
       end
 
       def to_i

--- a/lib/quickbooks/model/base_reference.rb
+++ b/lib/quickbooks/model/base_reference.rb
@@ -7,7 +7,11 @@ module Quickbooks
       xml_accessor :type, :from => '@type' # Attribute with name 'type'
 
       def initialize(attributes={})
-        attributes.each {|key, value| public_send("#{key}=", value) }
+        if attributes.kind_of?(Hash)
+          attributes.each {|key, value| public_send("#{key}=", value) }
+        else
+          self.value = attributes
+        end
       end
 
       def to_i

--- a/lib/quickbooks/model/base_reference.rb
+++ b/lib/quickbooks/model/base_reference.rb
@@ -6,8 +6,8 @@ module Quickbooks
       xml_accessor :value, :from => :content
       xml_accessor :type, :from => '@type' # Attribute with name 'type'
 
-      def initialize(value = nil)
-        self.value = value
+      def initialize(attributes={})
+        attributes.each {|key, value| public_send("#{key}=", value) }
       end
 
       def to_i

--- a/spec/lib/quickbooks/model/journal_entry_spec.rb
+++ b/spec/lib/quickbooks/model/journal_entry_spec.rb
@@ -27,8 +27,7 @@ describe "Quickbooks::Model::JournalEntry" do
     jel = Quickbooks::Model::JournalEntryLineDetail.new
     entity = Quickbooks::Model::Entity.new
     entity.type = 'Customer'
-    entity_ref = Quickbooks::Model::BaseReference.new(1)
-    entity_ref.name = 'James Rockenstall'
+    entity_ref = Quickbooks::Model::BaseReference.new(value: 1, name: 'James Rockenstall')
     entity.entity_ref = entity_ref
     jel.entity = entity
     line_item.journal_entry_line_detail = jel

--- a/spec/lib/quickbooks/model/journal_entry_spec.rb
+++ b/spec/lib/quickbooks/model/journal_entry_spec.rb
@@ -27,7 +27,7 @@ describe "Quickbooks::Model::JournalEntry" do
     jel = Quickbooks::Model::JournalEntryLineDetail.new
     entity = Quickbooks::Model::Entity.new
     entity.type = 'Customer'
-    entity_ref = Quickbooks::Model::BaseReference.new(value: 1, name: 'James Rockenstall')
+    entity_ref = Quickbooks::Model::BaseReference.new(1, name: 'James Rockenstall')
     entity.entity_ref = entity_ref
     jel.entity = entity
     line_item.journal_entry_line_detail = jel

--- a/spec/lib/quickbooks/service/attachable_spec.rb
+++ b/spec/lib/quickbooks/service/attachable_spec.rb
@@ -21,7 +21,7 @@ describe Quickbooks::Service::Account do
     attachable = Quickbooks::Model::Attachable.new
     attachable.file_name = "monkey.jpg"
     attachable.note = "A note"
-    entity = Quickbooks::Model::BaseReference.new(type: 'Customer', value: 3)
+    entity = Quickbooks::Model::BaseReference.new(3, type: 'Customer')
     attachable.attachable_ref = Quickbooks::Model::AttachableRef.new(entity)
     n = Nokogiri::XML(attachable.to_xml.to_s)
     n.at('AttachableRef > EntityRef').content.should == '3'

--- a/spec/lib/quickbooks/service/attachable_spec.rb
+++ b/spec/lib/quickbooks/service/attachable_spec.rb
@@ -21,9 +21,7 @@ describe Quickbooks::Service::Account do
     attachable = Quickbooks::Model::Attachable.new
     attachable.file_name = "monkey.jpg"
     attachable.note = "A note"
-    entity = Quickbooks::Model::BaseReference.new
-    entity.type = 'Customer'
-    entity.value = 3
+    entity = Quickbooks::Model::BaseReference.new(type: 'Customer', value: 3)
     attachable.attachable_ref = Quickbooks::Model::AttachableRef.new(entity)
     n = Nokogiri::XML(attachable.to_xml.to_s)
     n.at('AttachableRef > EntityRef').content.should == '3'

--- a/spec/lib/quickbooks/service/bill_payment_spec.rb
+++ b/spec/lib/quickbooks/service/bill_payment_spec.rb
@@ -1,7 +1,7 @@
 describe "Quickbooks::Service::BillPayment" do
   before(:all) { construct_service :bill_payment }
 
-  let(:vendor_ref) { Quickbooks::Model::BaseReference.new(value: 32) }
+  let(:vendor_ref) { Quickbooks::Model::BaseReference.new(32) }
   let(:model) { Quickbooks::Model::BillPayment }
   let(:bill_payment) do
     subject = model.new :id => 8748, :vendor_ref => vendor_ref

--- a/spec/lib/quickbooks/service/bill_payment_spec.rb
+++ b/spec/lib/quickbooks/service/bill_payment_spec.rb
@@ -1,7 +1,7 @@
 describe "Quickbooks::Service::BillPayment" do
   before(:all) { construct_service :bill_payment }
 
-  let(:vendor_ref) { Quickbooks::Model::BaseReference.new(:value => 32) }
+  let(:vendor_ref) { Quickbooks::Model::BaseReference.new(value: 32) }
   let(:model) { Quickbooks::Model::BillPayment }
   let(:bill_payment) do
     subject = model.new :id => 8748, :vendor_ref => vendor_ref

--- a/spec/lib/quickbooks/service/deposit_spec.rb
+++ b/spec/lib/quickbooks/service/deposit_spec.rb
@@ -1,7 +1,7 @@
 describe "Quickbooks::Service::Deposit" do
   before(:all) { construct_service :deposit }
 
-  # let(:customer_ref) { Quickbooks::Model::BaseReference.new(value: 42) }
+  # let(:customer_ref) { Quickbooks::Model::BaseReference.new(42) }
   let(:model) { Quickbooks::Model::Deposit }
   let(:deposit) { model.new :id => 8748 }
   let(:resource) { model::REST_RESOURCE }

--- a/spec/lib/quickbooks/service/deposit_spec.rb
+++ b/spec/lib/quickbooks/service/deposit_spec.rb
@@ -1,7 +1,7 @@
 describe "Quickbooks::Service::Deposit" do
   before(:all) { construct_service :deposit }
 
-  # let(:customer_ref) { Quickbooks::Model::BaseReference.new(:value => 42) }
+  # let(:customer_ref) { Quickbooks::Model::BaseReference.new(value: 42) }
   let(:model) { Quickbooks::Model::Deposit }
   let(:deposit) { model.new :id => 8748 }
   let(:resource) { model::REST_RESOURCE }

--- a/spec/lib/quickbooks/service/payment_spec.rb
+++ b/spec/lib/quickbooks/service/payment_spec.rb
@@ -1,7 +1,7 @@
 describe "Quickbooks::Service::Payment" do
   before(:all) { construct_service :payment }
 
-  let(:customer_ref) { Quickbooks::Model::BaseReference.new(value: 42) }
+  let(:customer_ref) { Quickbooks::Model::BaseReference.new(42) }
   let(:model) { Quickbooks::Model::Payment }
   let(:payment) { model.new :id => 8748, :customer_ref => customer_ref }
   let(:resource) { model::REST_RESOURCE }

--- a/spec/lib/quickbooks/service/payment_spec.rb
+++ b/spec/lib/quickbooks/service/payment_spec.rb
@@ -1,7 +1,7 @@
 describe "Quickbooks::Service::Payment" do
   before(:all) { construct_service :payment }
 
-  let(:customer_ref) { Quickbooks::Model::BaseReference.new(:value => 42) }
+  let(:customer_ref) { Quickbooks::Model::BaseReference.new(value: 42) }
   let(:model) { Quickbooks::Model::Payment }
   let(:payment) { model.new :id => 8748, :customer_ref => customer_ref }
   let(:resource) { model::REST_RESOURCE }

--- a/spec/lib/quickbooks/service/sales_receipt_spec.rb
+++ b/spec/lib/quickbooks/service/sales_receipt_spec.rb
@@ -48,9 +48,7 @@ module Quickbooks
         receipt = model.new
         receipt.customer_id = 2
 
-        shipping_reference = Quickbooks::Model::BaseReference.new
-        shipping_reference.name = 'FedEx'
-        shipping_reference.value = 'FedEx'
+        shipping_reference = Quickbooks::Model::BaseReference.new(name: 'FedEx', value: 'FedEx')
         receipt.ship_method_ref = shipping_reference
         receipt.txn_date = Time.now
         receipt.line_items = [line]

--- a/spec/lib/quickbooks/service/sales_receipt_spec.rb
+++ b/spec/lib/quickbooks/service/sales_receipt_spec.rb
@@ -48,7 +48,7 @@ module Quickbooks
         receipt = model.new
         receipt.customer_id = 2
 
-        shipping_reference = Quickbooks::Model::BaseReference.new(name: 'FedEx', value: 'FedEx')
+        shipping_reference = Quickbooks::Model::BaseReference.new('FedEx', name: 'FedEx')
         receipt.ship_method_ref = shipping_reference
         receipt.txn_date = Time.now
         receipt.line_items = [line]

--- a/spec/lib/quickbooks/service/time_activity_spec.rb
+++ b/spec/lib/quickbooks/service/time_activity_spec.rb
@@ -60,11 +60,11 @@ describe "Quickbooks::Service::TimeActivity" do
 
     stub_request(:post, @service.url_for_resource(model::REST_RESOURCE), ["200", "OK"], xml)
 
-    employee = Quickbooks::Model::BaseReference.new(value: 66, name: 'John Smith')
+    employee = Quickbooks::Model::BaseReference.new(66, name: 'John Smith')
 
-    item = Quickbooks::Model::BaseReference.new(value: 49, name: 'General Consulting')
+    item = Quickbooks::Model::BaseReference.new(49, name: 'General Consulting')
 
-    customer = Quickbooks::Model::BaseReference.new(value: 123, name: 'Test Customer')
+    customer = Quickbooks::Model::BaseReference.new(123, name: 'Test Customer')
 
     time_activity = Quickbooks::Model::TimeActivity.new
     time_activity.txn_date = Date.today

--- a/spec/lib/quickbooks/service/time_activity_spec.rb
+++ b/spec/lib/quickbooks/service/time_activity_spec.rb
@@ -60,14 +60,11 @@ describe "Quickbooks::Service::TimeActivity" do
 
     stub_request(:post, @service.url_for_resource(model::REST_RESOURCE), ["200", "OK"], xml)
 
-    employee = Quickbooks::Model::BaseReference.new(66)
-    employee.name = "John Smith"
+    employee = Quickbooks::Model::BaseReference.new(value: 66, name: 'John Smith')
 
-    item = Quickbooks::Model::BaseReference.new(49)
-    item.name = "General Consulting"
+    item = Quickbooks::Model::BaseReference.new(value: 49, name: 'General Consulting')
 
-    customer = Quickbooks::Model::BaseReference.new(123)
-    customer.name = "Test Customer"
+    customer = Quickbooks::Model::BaseReference.new(value: 123, name: 'Test Customer')
 
     time_activity = Quickbooks::Model::TimeActivity.new
     time_activity.txn_date = Date.today


### PR DESCRIPTION
Related to https://github.com/ruckus/quickbooks-ruby/issues/253

Divyas-MacBook-Pro:quickbooks-ruby divyakesapragada$ git push origin master
Counting objects: 20, done.
Delta compression using up to 8 threads.
Compressing objects: 100% (20/20), done.
Writing objects: 100% (20/20), 3.18 KiB | 0 bytes/s, done.
Total 20 (delta 14), reused 0 (delta 0)
To git@github.com:divyak-eligibleapi/quickbooks-ruby.git
   6c46373..dc2dedc  master -> master
Divyas-MacBook-Pro:quickbooks-ruby divyakesapragada$ bundle exec rspec spec
..................................................................................................................................................................................................................................................................................................................................................................

Finished in 1.73 seconds
354 examples, 0 failures
Coverage report generated for RSpec to /workspace/quickbooks-ruby/coverage. 2518 / 2634 LOC (95.6%) covered.