### PR TITLE
Move Definition module inside of Quickbooks::Model module.

### DIFF
--- a/lib/quickbooks/model/definition.rb
+++ b/lib/quickbooks/model/definition.rb
@@ -1,42 +1,46 @@
-module Definition
+module Quickbooks
+  module Model
+    module Definition
 
-  def self.included(base)
-    base.extend(ClassMethods)
-  end
+      def self.included(base)
+        base.extend(ClassMethods)
+      end
 
-  module ClassMethods
-    # https://developer.intuit.com/docs/0025_quickbooksapi/0050_data_services
-    TRANSACTION_ENTITIES = %w{
-      Bill
-      BillPayment
-      CreditMemo
-      Estimate
-      Invoice
-      JournalEntry
-      Payment
-      Purchase
-      PurchaseOrder
-      RefundReceipt
-      SalesReceipt
-      TimeActivity
-      VendorCredit
-    }
+      module ClassMethods
+        # https://developer.intuit.com/docs/0025_quickbooksapi/0050_data_services
+        TRANSACTION_ENTITIES = %w{
+          Bill
+          BillPayment
+          CreditMemo
+          Estimate
+          Invoice
+          JournalEntry
+          Payment
+          Purchase
+          PurchaseOrder
+          RefundReceipt
+          SalesReceipt
+          TimeActivity
+          VendorCredit
+        }
 
-    def is_transaction_entity?
-      TRANSACTION_ENTITIES.include?(self.name.demodulize)
+        def is_transaction_entity?
+          TRANSACTION_ENTITIES.include?(self.name.demodulize)
+        end
+
+        def is_name_list_entity?
+          !self.is_transaction_entity?
+        end
+      end
+
+      def is_transaction_entity?
+        self.class.is_transaction_entity?
+      end
+
+      def is_name_list_entity?
+        self.class.is_name_list_entity?
+      end
+
     end
-
-    def is_name_list_entity?
-      !self.is_transaction_entity?
-    end
   end
-
-  def is_transaction_entity?
-    self.class.is_transaction_entity?
-  end
-
-  def is_name_list_entity?
-    self.class.is_name_list_entity?
-  end
-
 end

--- a/spec/lib/quickbooks/model/base_model_spec.rb
+++ b/spec/lib/quickbooks/model/base_model_spec.rb
@@ -28,7 +28,7 @@ describe "Quickbooks::Model::BaseModel" do
 
     context "For a transaction entity" do
       before do
-        Definition::ClassMethods::TRANSACTION_ENTITIES.stub(include?: true)
+        Quickbooks::Model::Definition::ClassMethods::TRANSACTION_ENTITIES.stub(include?: true)
       end
 
       its(:is_transaction_entity?) { should be_true }


### PR DESCRIPTION
This fixes a bug in my rails application which contained a model
named Definition.  In staging when models were eager loaded, an
error is thrown because this gem defines a top level module called
Definition first.  This module should be nested inside the gems
module namespace and not be at the top level to avoid this clash.