### PR TITLE
Introduce ActiveRecord like methods to Quickbooks Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,11 +255,24 @@ customers.query(query, :page => 2, :per_page => 25)
 ### Querying in Batches
 
 Often one needs to retrieve multiple pages of records of an Entity type
-and loop over them all. Fortunately there is the `query_in_batches` collection method:
+and loop over them all. Again there are two approaches currently supported and first approach is encouraged to be used.
+
+###### Approach 1
+```ruby
+Quickbooks::Configuration.set_tokens_and_realm_id(token, secret, realm_id)
+Quickbooks::Model::Customer.query_in_batches(query, per_page: 1000) do |batch|
+  batch.each do |customer|
+    # ...
+  end
+end
+```
+###### Approach 2
+As of second approach, there is the `query_in_batches` collection method in each service:
 
 ```ruby
+service = Quickbooks::Service::Customer.new(:company_id => "123", :access_token => access_token)
 query = nil
-Customer.query_in_batches(query, per_page: 1000) do |batch|
+service.query_in_batches(query, per_page: 1000) do |batch|
   batch.each do |customer|
     # ...
   end

--- a/README.md
+++ b/README.md
@@ -175,7 +175,43 @@ end
 
 ## Getting Started - Retrieving a list of Customers
 
-The general approach is you first instantiate a `Service` object based on the entity you would like to retrieve. Lets retrieve a list of Customers:
+There are two approaches to retrieve results from Quickbooks. However, you're encouraged to use the first approach as we'll be removing the second approach in the long run.
+
+###### Approach 1
+To retrieve any Quickbooks results you need to set the access token, secret key and realm id in Quickbooks configuration:
+```ruby
+Quickbooks::Configuration.set_tokens_and_realm_id(token, secret, realm_id)
+```
+Then you can simply call `Quickbooks::Model::Customer.all` to retrieve a list of all customers. However, there is a default pagination applied and only 20 records are fetched per request. If you want to skip pagination and just want to fetch all the records then you can pass `skip_pagination: true` argument to `Quickbooks::Model::Customer.all`:
+```ruby
+Quickbooks::Model::Customer.all #=> Returns array of first 20 customers
+Quickbooks::Model::Customer.all(nil, skip_pagination: true) #=> Returns array of all customers
+```
+The first argument in the method is query and if you don't pass any query then the default query will be executed which is, in this case, `SELECT * FROM Customer`
+
+Quickbooks models behave exactly the same like ActiveRecord for querying purposes. That means that these models have other methods e.g: `where` `count` `find_by` `find` etc. Following are some examples:
+```ruby
+Quickbooks::Configuration.set_tokens_and_realm_id(token, secret, realm_id)
+
+# where
+Quickbooks::Model::Customer.where('') #=> runs default query and returns first 20 customers
+Quickbooks::Model::Customer.where(id: 170) #=> runs a conditional query and returns first 20 customers having id equal to 170
+Quickbooks::Model::Customer.where(id: 170, skip_pagination: true) #=> runs the conditional query and returns all customers having id equal to 170 without pagination
+
+# find_by
+Quickbooks::Model::Customer.find_by('') #=> runs default query and returns first customer
+Quickbooks::Model::Customer.find_by(id: 170) #=> runs a conditional query and returns first customer having id equal to 170
+
+# find
+Quickbooks::Model::Customer.find('') #=> runs default query and returns first customer
+Quickbooks::Model::Customer.find(170) #=> runs a conditional query and returns first customer having id equal to 170
+
+# count
+Quickbooks::Model::Customer.count #=> returns total number of customers in your quickbooks account
+```
+
+###### Approach 2
+The second approach is you first instantiate a `Service` object based on the entity you would like to retrieve. Lets retrieve a list of Customers:
 
 ```ruby
 

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -1,0 +1,9 @@
+module Quickbooks
+  class Configuration
+    def self.set_tokens_and_realm_id token, secret, realm_id
+      Thread.current[:token]    = token
+      Thread.current[:secret]   = secret
+      Thread.current[:realm_id] = realm_id
+    end
+  end
+end

--- a/lib/quickbooks-ruby.rb
+++ b/lib/quickbooks-ruby.rb
@@ -17,6 +17,7 @@ require 'quickbooks/util/query_builder'
 #== Models
 require 'quickbooks/model/definition'
 require 'quickbooks/model/validator'
+require 'quickbooks/model/active_record_scaffold'
 require 'quickbooks/model/base_model'
 require 'quickbooks/model/base_model_json'
 require 'quickbooks/model/base_reference'
@@ -162,21 +163,12 @@ require 'quickbooks/service/payment_change'
 
 module Quickbooks
   @@sandbox_mode     = false
-  @@allow_pagination = true
 
   @@logger = nil
 
   class << self
     def sandbox_mode
       @@sandbox_mode
-    end
-
-    def allow_pagination?
-      @@allow_pagination
-    end
-
-    def allow_pagination=(allow_pagination)
-      @@allow_pagination = allow_pagination
     end
 
     def sandbox_mode=(sandbox_mode)

--- a/lib/quickbooks-ruby.rb
+++ b/lib/quickbooks-ruby.rb
@@ -13,6 +13,7 @@ require 'quickbooks/util/logging'
 require 'quickbooks/util/http_encoding_helper'
 require 'quickbooks/util/name_entity'
 require 'quickbooks/util/query_builder'
+require 'configuration'
 
 #== Models
 require 'quickbooks/model/definition'
@@ -217,14 +218,6 @@ module Quickbooks
     def initialize(msg)
       self.message = msg
       super(msg)
-    end
-  end
-
-  class Configuration
-    def self.set_tokens_and_realm_id token, secret, realm_id
-      Thread.current[:token]    = token
-      Thread.current[:secret]   = secret
-      Thread.current[:realm_id] = realm_id
     end
   end
 

--- a/lib/quickbooks-ruby.rb
+++ b/lib/quickbooks-ruby.rb
@@ -161,13 +161,22 @@ require 'quickbooks/service/credit_memo_change'
 require 'quickbooks/service/payment_change'
 
 module Quickbooks
-  @@sandbox_mode = false
+  @@sandbox_mode     = false
+  @@allow_pagination = true
 
   @@logger = nil
 
   class << self
     def sandbox_mode
       @@sandbox_mode
+    end
+
+    def allow_pagination?
+      @@allow_pagination
+    end
+
+    def allow_pagination=(allow_pagination)
+      @@allow_pagination = allow_pagination
     end
 
     def sandbox_mode=(sandbox_mode)
@@ -216,6 +225,14 @@ module Quickbooks
     def initialize(msg)
       self.message = msg
       super(msg)
+    end
+  end
+
+  class Configuration
+    def self.set_tokens_and_realm_id token, secret, realm_id
+      Thread.current[:token]    = token
+      Thread.current[:secret]   = secret
+      Thread.current[:realm_id] = realm_id
     end
   end
 

--- a/lib/quickbooks/model/active_record_scaffold.rb
+++ b/lib/quickbooks/model/active_record_scaffold.rb
@@ -1,0 +1,81 @@
+module Quickbooks
+  module Model
+    module ActiveRecordScaffold
+
+      def self.included(base)
+        base.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        def all(query = nil, options = {})
+          initialize_service(options).query(query, options).entries
+        end
+
+        def where(options = {})
+          if options.is_a?(String)
+            all(build_string_query(options), {})
+          elsif options.present?
+            all(build_hash_query(options.except(:skip_pagination)), options)
+          else
+            all(full_query, {})
+          end
+        end
+
+        def find_by(options = {})
+          where(options).first
+        end
+
+        def find(id)
+          find_by(id: id)
+        end
+
+        def count
+          initialize_service.query("SELECT COUNT(*) FROM #{model}").total_count
+        end
+
+        private
+
+        def initialize_service(options = {})
+          service              = eval("Quickbooks::Service::#{model}").new
+          service.access_token = OAuth::AccessToken.new(
+            $qb_oauth_consumer, options[:token] || Thread.current[:token],
+            options[:secret] || Thread.current[:secret]
+          )
+          service.company_id   = options[:realm_id] || Thread.current[:realm_id]
+          service
+        end
+
+        def build_string_query(query = nil)
+          unless query.downcase.starts_with?('select ')
+            query = query.present? ? "#{conditional_query} #{query}" : full_query
+          end
+          query
+        end
+
+        def build_hash_query(options = {})
+          query_builder = Quickbooks::Util::QueryBuilder.new
+          conditions = options.collect do |key, value|
+            if value.is_a?(Array)
+              query_builder.clause(key, 'IN', value)
+            else
+              query_builder.clause(key, '=', value)
+            end
+          end.join(' AND ')
+          conditional_query + conditions
+        end
+
+        def conditional_query
+          "#{full_query} WHERE "
+        end
+
+        def full_query
+          "SELECT * FROM #{model}"
+        end
+
+        def model
+          self.name.split('::').last
+        end
+      end
+    end
+  end
+end

--- a/lib/quickbooks/model/active_record_scaffold.rb
+++ b/lib/quickbooks/model/active_record_scaffold.rb
@@ -33,6 +33,10 @@ module Quickbooks
           initialize_service.query("SELECT COUNT(*) FROM #{model}").total_count
         end
 
+        def query_in_batches(options = {})
+          initialize_service(options).query_in_batches(query, options).entries
+        end
+
         private
 
         def initialize_service(options = {})

--- a/lib/quickbooks/model/base_model.rb
+++ b/lib/quickbooks/model/base_model.rb
@@ -12,6 +12,13 @@ module Quickbooks
         attributes.each {|key, value| public_send("#{key}=", value) }
       end
 
+      def self.all token, secret, realm_id
+        service = eval("Quickbooks::Service::#{self.name.split('::').last}").new
+        service.access_token = OAuth::AccessToken.new($qb_oauth_consumer, token, secret);
+        service.company_id = realm_id
+        service.query()
+      end
+
       # ROXML doesnt insert the namespaces into generated XML so we need to do it ourselves
       # insert the static namespaces in the first opening tag that matches the +model_name+
       def to_xml_inject_ns(model_name, options = {})

--- a/lib/quickbooks/model/base_model.rb
+++ b/lib/quickbooks/model/base_model.rb
@@ -12,11 +12,46 @@ module Quickbooks
         attributes.each {|key, value| public_send("#{key}=", value) }
       end
 
-      def self.all token, secret, realm_id
-        service = eval("Quickbooks::Service::#{self.name.split('::').last}").new
-        service.access_token = OAuth::AccessToken.new($qb_oauth_consumer, token, secret);
-        service.company_id = realm_id
-        service.query()
+      def self.all query = nil, options = {}
+        model_name           = self.name.split('::').last
+        query                = "SELECT * FROM #{model_name}" if query.blank?
+        service              = eval("Quickbooks::Service::#{model_name}").new
+        service.access_token = OAuth::AccessToken.new(
+          $qb_oauth_consumer, options[:token] || Thread.current[:token],
+          options[:secret] || Thread.current[:secret]
+        )
+        service.company_id   = options[:realm_id] || Thread.current[:realm_id]
+        service.query(query).entries
+      end
+
+      def self.where options = {}
+        model_name = self.name.split('::').last
+        query      = options.present? ? "SELECT * FROM #{model_name} WHERE " : "SELECT * FROM #{model_name}"
+        if options.is_a?(String)
+          conditions = options
+        else
+          conditions = options.collect do |key, value|
+            if value.is_a?(Array)
+              "#{key} IN ('#{value.join("','")}')"
+            else
+              "#{key}='#{value}'"
+            end
+          end.join(' AND ')
+        end
+        query += conditions
+        all(query, options)
+      end
+
+      def self.find_by options = {}
+        where(options).first
+      end
+
+      def self.find id
+        find_by(id: id)
+      end
+
+      def self.count options = {}
+        where(options).length
       end
 
       # ROXML doesnt insert the namespaces into generated XML so we need to do it ourselves

--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -53,9 +53,9 @@ module Quickbooks
         "SELECT * FROM #{self.class.name.split("::").last}"
       end
 
-      def url_for_query(query = nil, start_position = 1, max_results = 20)
+      def url_for_query(query = nil, start_position = 1, max_results = 20, options = {})
         query ||= default_model_query
-        if Quickbooks.allow_pagination?
+        unless options[:skip_pagination]
           query = "#{query} STARTPOSITION #{start_position} MAXRESULTS #{max_results}"
         end
 
@@ -92,7 +92,7 @@ module Quickbooks
         start_position = ((page - 1) * per_page) + 1 # page=2, per_page=10 then we want to start at 11
         max_results = per_page
 
-        response = do_http_get(url_for_query(query, start_position, max_results))
+        response = do_http_get(url_for_query(query, start_position, max_results, options))
 
         parse_collection(response, model)
       end

--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -55,7 +55,9 @@ module Quickbooks
 
       def url_for_query(query = nil, start_position = 1, max_results = 20)
         query ||= default_model_query
-        query = "#{query} STARTPOSITION #{start_position} MAXRESULTS #{max_results}"
+        if Quickbooks.allow_pagination?
+          query = "#{query} STARTPOSITION #{start_position} MAXRESULTS #{max_results}"
+        end
 
         "#{url_for_base}/query?query=#{URI.encode_www_form_component(query)}"
       end

--- a/lib/quickbooks/service/change_service.rb
+++ b/lib/quickbooks/service/change_service.rb
@@ -2,7 +2,7 @@ module Quickbooks
   module Service
     class ChangeService < BaseService
 
-      def url_for_query(query = nil, start_position = 1, max_results = 20)
+      def url_for_query(query = nil, start_position = 1, max_results = 20, options = {})
         q = entity
         q = "#{q}&#{query}" if query.present?
 

--- a/lib/quickbooks/util/query_builder.rb
+++ b/lib/quickbooks/util/query_builder.rb
@@ -19,7 +19,7 @@ module Quickbooks
                   value = value.map{|v| v.to_s.gsub("'", "\\\\'") }
                 else
                   # escape single quotes with an escaped backslash
-                  value = value.gsub("'", "\\\\'")
+                  value = value.to_s.gsub("'", "\\\\'")
                 end
 
         if operator.downcase == 'in' && value.is_a?(Array)


### PR DESCRIPTION
- This PR introduces some methods i.e. `all, where, find_by, find, count` methods to quickbooks models. This change eliminates the requirement of using services to query something from Quickbooks. You can directly call `Quickbooks::Models::Invoice.all` to get all the invoices.
- ~~Another setting `allow_pagination` is introduced in this PR. This is a boolean setting which is set to `true` by default. If user sets this setting to `false` then no pagination will be applied and all the records will be returned on any query.~~

---
- The golbal setting `allow_pagination` has been removed which I introduced in my last commit. Instead of that, I've introduced another option to skip pagination on each request basis i.e. `skip_pagination`. This setting will be available in both the conventional query method and the new methods introduced in this PR.

- [ ] I'm working on updating the `README.md` file.