### PR TITLE
Add minorversion 4 support to Item service and model, reference #270

### DIFF
--- a/lib/quickbooks/model/item.rb
+++ b/lib/quickbooks/model/item.rb
@@ -12,7 +12,7 @@ module Quickbooks
       REST_RESOURCE = 'item'
 
       INVENTORY_TYPE = 'Inventory'
-      NON_INVENTORY_TYPE = 'Non Inventory'
+      NON_INVENTORY_TYPE = 'NonInventory'
       SERVICE_TYPE = 'Service'
       ITEM_TYPES = [INVENTORY_TYPE, NON_INVENTORY_TYPE, SERVICE_TYPE]
 

--- a/lib/quickbooks/service/item.rb
+++ b/lib/quickbooks/service/item.rb
@@ -7,6 +7,16 @@ module Quickbooks
         update(item, :sparse => true)
       end
 
+      def url_for_resource(resource)
+        url = super(resource)
+        url + "?minorversion=4"
+      end
+
+      def url_for_query(query = nil, start_position = 1, max_results = 20)
+        url = super(query, start_position, max_results)
+        url + "&minorversion=4"
+      end
+
       private
 
       def model

--- a/lib/quickbooks/service/item.rb
+++ b/lib/quickbooks/service/item.rb
@@ -1,7 +1,7 @@
 module Quickbooks
   module Service
     class Item < BaseService
-
+      MINORVERSION = 4
       def delete(item)
         item.active = false
         update(item, :sparse => true)
@@ -9,12 +9,12 @@ module Quickbooks
 
       def url_for_resource(resource)
         url = super(resource)
-        url + "?minorversion=4"
+        url + "?minorversion=%d" % MINORVERSION
       end
 
       def url_for_query(query = nil, start_position = 1, max_results = 20)
         url = super(query, start_position, max_results)
-        url + "&minorversion=4"
+        url + "&minorversion=%d" % MINORVERSION
       end
 
       private


### PR DESCRIPTION
Without minorversion 4, Non-Inventory items are not supported for the Item object.

Reference issue #270.  Non inventory items will be returned from Quickbooks Online with the Type attribute set to "Service" even though in Quickbooks the item will appear as a "Non Inventory" item.

This PR implements setting minorversion=4 only for the Item service and model to enable support for Non Inventory items. 