### PR TITLE
Adding Helpers to ServiceCrud:  all and find_by

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,14 @@ If you're are running a custom Query then pass it instead.
 The second argument is the options, which are optional.
 By default, the options are `per_page: 1000`.
 
+## Retrieving all objects
+
+You may retrieve an array of objects like so:
+```ruby
+customers = service.all
+```
+Unlike other query functions which return a Quickbooks::Collection object,
+the all method returns an array of objects.
 
 ## Retrieving a single object
 
@@ -246,6 +254,16 @@ You can retrieve a specific Intuit object like so:
 customer = service.fetch_by_id("99")
 puts customer.company_name
 => "Acme Enterprises"
+```
+## Retrieving objects with matching attributes
+
+The `find_by(attribute, value)` method allows you to retrieve objects with a simple WHERE query using a single attribute.  The attribute may be given as a symbol or a string.
+Symbols will be automatically camelcased to match the Quickbooks API field names.
+
+```ruby
+customer = service.find_by(:family_name, "Doe")
+or
+customer = service.find_by("FamilyName", "Doe")
 ```
 
 ## Updating an object
@@ -592,7 +610,7 @@ See the [specs](https://github.com/ruckus/quickbooks-ruby/blob/master/spec/lib/q
 Intuit started the v3 API supporting both XML and JSON. However, new
 v3 API services such as `Tax Service` [will only support
 JSON]( https://github.com/ruckus/quickbooks-ruby/issues/257#issuecomment-126834454 ). This gem has
-[ roots ](https://github.com/ruckus/quickeebooks) in the v2 API, which was XML only, and hence was constructed supporting XML only. 
+[ roots ](https://github.com/ruckus/quickeebooks) in the v2 API, which was XML only, and hence was constructed supporting XML only.
 
 That said, the `Tax Service` is supported and other new v3-API-JSON-only services will be supported. Ideally, we would like to fully support JSON for all entities and services for the `1.0.0` release. Please jump in and contribute to help that aim.
 

--- a/lib/quickbooks/service/service_crud.rb
+++ b/lib/quickbooks/service/service_crud.rb
@@ -6,7 +6,8 @@ module Quickbooks
         fetch_collection(object_query, model, options)
       end
 
-      def query_all(object_query=nil, options={})
+      # fetch all records, returns an array of models
+      def all(object_query=nil, options={})
         collection = []
         self.query_in_batches(object_query, options) do |batch|
           collection << batch.entries
@@ -22,6 +23,14 @@ module Quickbooks
           results = query(object_query, page: page, per_page: per_page)
           yield results if results.count > 0
         end until results.count < per_page
+      end
+
+      def find_by(field, selector, options={})
+        if field.class == Symbol
+          field = field.to_s.camelcase
+        end
+        q = "select * from %s where %s = '%s'" % [model.resource_for_singular, field, selector]
+        self.query(q, options)
       end
 
       def fetch_by_id(id, params = {})

--- a/lib/quickbooks/service/service_crud.rb
+++ b/lib/quickbooks/service/service_crud.rb
@@ -6,6 +6,14 @@ module Quickbooks
         fetch_collection(object_query, model, options)
       end
 
+      def query_all(object_query=nil, options={})
+        collection = []
+        self.query_in_batches(object_query, options) do |batch|
+          collection << batch.entries
+        end
+        collection.flatten!
+      end
+
       def query_in_batches(object_query=nil, options={})
         page = 0
         per_page = options.delete(:per_page) || 1_000

--- a/spec/lib/quickbooks/service/service_crud_spec.rb
+++ b/spec/lib/quickbooks/service/service_crud_spec.rb
@@ -38,6 +38,20 @@ module Quickbooks
         expect(yielded.size).to eq 1
       end
 
+      it "finds by attribute" do
+        results = double(Quickbooks::Collection, count: 1)
+        ServicedClass.should_receive(:resource_for_singular).and_return ServicedClass
+        ServicedClass.should_receive(:model).and_return ServicedClass
+        ServicedClass.should_receive(:query).with("select * from ServicedClass where Name = 'test'", {})
+        ServicedClass.find_by(:name, "test")
+      end
+
+      it "finds all" do
+        results = double(Quickbooks::Collection, count: 1)
+        results.should_receive(:entries).and_return []
+        ServicedClass.should_receive(:query).with(nil, page: 1, per_page: 1000).and_return(results)
+        ServicedClass.all
+      end
     end
   end
 end


### PR DESCRIPTION
Similar to ActiveRecord, we have implemented two new functions in the ServiceCrud module.

1. all:  fetches all records and returns an array of the results.  An array is returned because we could not figure out how to append results to the Collection class; so this may warrant another look. 

2. find_by( attribute, value)  This function allows finding by a given attribute value, e.g. item_service.find_by(:name, "Tire")
