### PR TITLE
correct fetch_by_id method url method

### DIFF
--- a/lib/quickbooks/service/item.rb
+++ b/lib/quickbooks/service/item.rb
@@ -7,13 +7,13 @@ module Quickbooks
         update(item, :sparse => true)
       end
 
-      # def url_for_resource(resource)
-      #   url = super(resource)
-      #   "#{url}?minorversion=#{Quickbooks::Model::Item::MINORVERSION}"
-      # end
+      def url_for_resource(resource)
+        url = super(resource)
+        "#{url}?minorversion=#{Quickbooks::Model::Item::MINORVERSION}"
+      end
 
       def fetch_by_id(id, params = {})
-        url = "#{url_for_resource(model.resource_for_singular)}/#{id}?minorversion=#{Quickbooks::Model::Item::MINORVERSION}"
+        url = "#{url_for_base}/item/#{id}?minorversion=#{Quickbooks::Model::Item::MINORVERSION}"
         fetch_object(model, url, params)
       end
 

--- a/lib/quickbooks/service/item.rb
+++ b/lib/quickbooks/service/item.rb
@@ -7,9 +7,14 @@ module Quickbooks
         update(item, :sparse => true)
       end
 
-      def url_for_resource(resource)
-        url = super(resource)
-        "#{url}?minorversion=#{Quickbooks::Model::Item::MINORVERSION}"
+      # def url_for_resource(resource)
+      #   url = super(resource)
+      #   "#{url}?minorversion=#{Quickbooks::Model::Item::MINORVERSION}"
+      # end
+
+      def fetch_by_id(id, params = {})
+        url = "#{url_for_resource(model.resource_for_singular)}/#{id}?minorversion=#{Quickbooks::Model::Item::MINORVERSION}"
+        fetch_object(model, url, params)
       end
 
       def url_for_query(query = nil, start_position = 1, max_results = 20)

--- a/spec/lib/quickbooks/service/item_spec.rb
+++ b/spec/lib/quickbooks/service/item_spec.rb
@@ -18,7 +18,7 @@ describe "Quickbooks::Service::Item" do
   it "can fetch an Item by ID" do
     xml = fixture("fetch_item_by_id.xml")
     model = Quickbooks::Model::Item
-    stub_request(:get, "#{@service.url_for_resource(model::REST_RESOURCE)}/2", ["200", "OK"], xml)
+    stub_request(:get, "#{@service.url_for_resource(model::REST_RESOURCE)}/2?minorversion=#{Quickbooks::Model::Item::MINORVERSION}", ["200", "OK"], xml)
     item = @service.fetch_by_id(2)
     item.name.should == "Plush Baby Doll"
   end

--- a/spec/lib/quickbooks/service/item_spec.rb
+++ b/spec/lib/quickbooks/service/item_spec.rb
@@ -18,7 +18,7 @@ describe "Quickbooks::Service::Item" do
   it "can fetch an Item by ID" do
     xml = fixture("fetch_item_by_id.xml")
     model = Quickbooks::Model::Item
-    stub_request(:get, "#{@service.url_for_resource(model::REST_RESOURCE)}/2?minorversion=#{Quickbooks::Model::Item::MINORVERSION}", ["200", "OK"], xml)
+    stub_request(:get, "#{@service.url_for_base}/item/2?minorversion=#{Quickbooks::Model::Item::MINORVERSION}", ["200", "OK"], xml)
     item = @service.fetch_by_id(2)
     item.name.should == "Plush Baby Doll"
   end


### PR DESCRIPTION
Skip using the ```url_for_resource``` method to build the url for ```fetch_by_id``` so that you can include the ```minorversion``` param in other methods. 