### PR TITLE
added void method for service/payment

### DIFF
--- a/lib/quickbooks/service/payment.rb
+++ b/lib/quickbooks/service/payment.rb
@@ -6,6 +6,20 @@ module Quickbooks
         delete_by_query_string(payment)
       end
 
+      def void(entity, options = {})
+        raise Quickbooks::InvalidModelException.new(entity.errors.full_messages.join(',')) unless entity.valid?
+        xml = entity.to_xml_ns(options)
+        url = url_for_resource(model.resource_for_singular)
+        url += '?include=void'
+
+        response = do_http_post(url, valid_xml_document(xml), {})
+        if response.code.to_i == 200
+          model.from_xml(parse_singular_entity_response(model, response.plain_body))
+        else
+          nil
+        end
+      end
+
       private
 
       def model

--- a/spec/fixtures/payment_void_response_success.xml
+++ b/spec/fixtures/payment_void_response_success.xml
@@ -1,0 +1,17 @@
+<IntuitResponse xmlns="http://schema.intuit.com/finance/v3" time="2013-04-23T08:30:33.626-07:00">
+ <Payment domain="QBO" sparse="true">
+    <Id>8748</Id>
+    <SyncToken>0</SyncToken>
+    <MetaData>
+       <CreateTime>2013-07-11T17:51:41-07:00</CreateTime>
+       <LastUpdatedTime>2013-07-11T17:51:42-07:00</LastUpdatedTime>
+    </MetaData>
+    <TxnDate>2013-07-11</TxnDate>
+    <PrivateNote>Voided</PrivateNote>
+    <CustomerRef>25342</CustomerRef>
+    <DepositToAccountRef>4</DepositToAccountRef>
+    <TotalAmt>0</TotalAmt>
+    <UnappliedAmt>0</UnappliedAmt>
+    <ProcessPayment>false</ProcessPayment>
+ </Payment>
+</IntuitResponse>

--- a/spec/lib/quickbooks/service/payment_spec.rb
+++ b/spec/lib/quickbooks/service/payment_spec.rb
@@ -65,6 +65,18 @@ describe "Quickbooks::Service::Payment" do
     response.should be_true
   end
 
+  it 'can void a payment' do
+    stub_request(:post,
+                 "#{@service.url_for_resource(resource)}?include=void",
+                 ["200", "OK"],
+                 fixture("payment_void_response_success.xml"))
+
+    response = @service.void(payment)
+
+    response.should be_true    
+    response.total.should == 0
+  end
+
   it "properly outputs BigDecimal fields" do
     payment.total = payment.unapplied_amount = payment.exchange_rate = "42"
 


### PR DESCRIPTION
[QBO Void Payment Docs](https://developer.intuit.com/docs/api/accounting/Payment)

One more.   Added a ```void``` method to the payment service so that you can utilize that QBO API functionality.  