### PR TITLE
add item type 'category' to valid item types

### DIFF
--- a/lib/quickbooks/model/item.rb
+++ b/lib/quickbooks/model/item.rb
@@ -15,7 +15,8 @@ module Quickbooks
       INVENTORY_TYPE = 'Inventory'
       NON_INVENTORY_TYPE = 'NonInventory'
       SERVICE_TYPE = 'Service'
-      ITEM_TYPES = [INVENTORY_TYPE, NON_INVENTORY_TYPE, SERVICE_TYPE]
+      CATEGORY_TYPE = 'Category'
+      ITEM_TYPES = [INVENTORY_TYPE, NON_INVENTORY_TYPE, SERVICE_TYPE, CATEGORY_TYPE]
 
       xml_name 'Item'
       xml_accessor :id, :from => 'Id'


### PR DESCRIPTION
As of Nov 14, 2015 there is a new item type called 'Category'. See Intuit documentation here:
https://developer.intuit.com/docs/api/accounting/item

> In addition to the above, QuickBooks companies will start supporting item categories to define item hierarchies... ... Use Item.Type set to Category to create hierarchies. See Migrating to categories for integration information and see Category object definition and CRUD examples on this page.