### PR TITLE
Remove dependency on alias_method_chain from create_http_request method.

### DIFF
--- a/lib/quickbooks/util/multipart.rb
+++ b/lib/quickbooks/util/multipart.rb
@@ -4,7 +4,7 @@ end
 require "oauth"
 
 OAuth::Consumer.class_eval do
-  def create_http_request_with_multipart(http_method, path, *arguments)
+  def create_http_request(http_method, path, *arguments)
     http_method = http_method.to_sym
 
     if [:post, :put].include?(http_method)
@@ -60,8 +60,6 @@ OAuth::Consumer.class_eval do
     request
 
   end
-
-  alias_method_chain :create_http_request, :multipart
 end
 
 OAuth::AccessToken.class_eval do


### PR DESCRIPTION
I took a look at this with another member of my team and we felt that removing the dependency on the alias_method_chain was the best way to go here given the way the code was written.  This assumes compatibility with the existing create_http_request method, as we believe was the original intent of the code.  Passes tests.