### PR TITLE
Update Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ meta.attachable_ref = Quickbooks::Model::AttachableRef.new(entity)
 ### Uploading an actual file
 
 ```ruby
-upload_service = Quickbooks::Model::Upload.new
+upload_service = Quickbooks::Service::Upload.new
 
 # args:
 #     local-path to file


### PR DESCRIPTION
Hi Ruckus, 

 I noticed that in the documentation it is stated that to actually upload a file you need to instance the following object:

`upload_service = Quickbooks::Model::Upload.new`

 The problem with that is that the method doesn't exist. The method that actually exist and that worked in my project is under the "Service" module, located at lib/quickbooks/service/upload.rb. This is the code in that file:

```
module Quickbooks
  module Service
    class Upload < BaseService

      XML_NODE = "AttachableResponse"

      # path_to_file: String - path to file
      # mime_type: String - the MIME type of the file, e.g. image/jpeg
      # attachable: Quickbooks::Model::Attachable meta-data details, can be null
      def upload(path_to_file, mime_type, attachable = nil)
        url = url_for_resource("upload")
        uploadIO = UploadIO.new(path_to_file, mime_type)
        response = do_http_file_upload(uploadIO, url, attachable)
        prefix = "AttachableResponse/xmlns:Attachable"...
```