### PR TITLE
Fix duplicate spec name.

### DIFF
--- a/spec/lib/quickbooks/service/time_activity_spec.rb
+++ b/spec/lib/quickbooks/service/time_activity_spec.rb
@@ -43,7 +43,7 @@ describe "Quickbooks::Service::TimeActivity" do
     time_activity.errors.keys.include?(:employee_ref).should == true
   end
 
-  it "cannot create a time_activity with an empty employee_ref" do
+  it "cannot create a time_activity with an empty vendor_ref" do
     time_activity = Quickbooks::Model::TimeActivity.new
     time_activity.name_of = "Vendor"
     lambda do


### PR DESCRIPTION
It was saying it shouldn't create with an empty employee_ref but was testing for vendor_ref.