### PR TITLE
don't go :boom: when a NameValue pair is missing

### DIFF
--- a/lib/quickbooks/model/company_info.rb
+++ b/lib/quickbooks/model/company_info.rb
@@ -25,7 +25,8 @@ module Quickbooks
       xml_accessor :name_values, :from => 'NameValue', :as => [NameValue]
 
       def find_name_value(name)
-        name_values.select { |nv| nv.name == name }.first.value
+        nv = name_values.find { |nv| nv.name == name }
+        nv ? nv.value : nil
       end
 
       def find_boolean_name_value(name)

--- a/spec/lib/quickbooks/model/company_info_spec.rb
+++ b/spec/lib/quickbooks/model/company_info_spec.rb
@@ -66,5 +66,7 @@ describe "Quickbooks::Model::CompanyInfo" do
     company_info.neo_enabled.should be_false
     company_info.payroll_feature.should be_false
     company_info.accountant_feature.should be_false
+
+    company_info.find_name_value('Missing').should be_nil
   end
 end


### PR DESCRIPTION
I stumbled on this when using sandbox data. When calling company_info.industry_code for some reason that pair wasn't in the data and it throws a nil exception.

Wasn't sure if that's the desired behavior, so here's a fix if it's not.