### PR TITLE
Support Void for Invoice & SalesReceipt

### DIFF
--- a/lib/quickbooks/service/invoice.rb
+++ b/lib/quickbooks/service/invoice.rb
@@ -23,6 +23,19 @@ module Quickbooks
         response.plain_body
       end
 
+      def void(invoice, options = {})
+        raise Quickbooks::InvalidModelException.new(invoice.errors.full_messages.join(',')) unless invoice.valid?
+        xml = invoice.to_xml_ns(options)
+        url = "#{url_for_resource(model::REST_RESOURCE)}?include=void"
+
+        response = do_http_post(url, valid_xml_document(xml), {})
+        if response.code.to_i == 200
+          model.from_xml(parse_singular_entity_response(model, response.plain_body))
+        else
+          false
+        end
+      end
+
       private
 
       def model

--- a/lib/quickbooks/service/payment.rb
+++ b/lib/quickbooks/service/payment.rb
@@ -9,14 +9,13 @@ module Quickbooks
       def void(entity, options = {})
         raise Quickbooks::InvalidModelException.new(entity.errors.full_messages.join(',')) unless entity.valid?
         xml = entity.to_xml_ns(options)
-        url = url_for_resource(model.resource_for_singular)
-        url += '?include=void'
+        url = "#{url_for_resource(model::REST_RESOURCE)}?include=void"
 
         response = do_http_post(url, valid_xml_document(xml), {})
         if response.code.to_i == 200
           model.from_xml(parse_singular_entity_response(model, response.plain_body))
         else
-          nil
+          false
         end
       end
 

--- a/lib/quickbooks/service/sales_receipt.rb
+++ b/lib/quickbooks/service/sales_receipt.rb
@@ -12,6 +12,19 @@ module Quickbooks
         response.plain_body
       end
 
+      def void(sales_receipt, options = {})
+        raise Quickbooks::InvalidModelException.new(sales_receipt.errors.full_messages.join(',')) unless sales_receipt.valid?
+        xml = sales_receipt.to_xml_ns(options)
+        url = "#{url_for_resource(model::REST_RESOURCE)}?include=void"
+
+        response = do_http_post(url, valid_xml_document(xml), {})
+        if response.code.to_i == 200
+          model.from_xml(parse_singular_entity_response(model, response.plain_body))
+        else
+          false
+        end
+      end
+
       private
 
       def model

--- a/spec/fixtures/invoice_void_success_response.xml
+++ b/spec/fixtures/invoice_void_success_response.xml
@@ -1,0 +1,65 @@
+<IntuitResponse xmlns="http://schema.intuit.com/finance/v3" time="2013-11-15T15:25:09.985-08:00">
+  <Invoice domain="QBO" sparse="false">
+    <Id>1</Id>
+    <SyncToken>0</SyncToken>
+    <MetaData>
+      <CreateTime>2013-11-15T15:22:43-08:00</CreateTime>
+      <LastUpdatedTime>2013-11-15T15:22:43-08:00</LastUpdatedTime>
+    </MetaData>
+    <DocNumber>1001</DocNumber>
+    <TxnDate>2013-11-15</TxnDate>
+    <CurrencyRef name="United States Dollar">USD</CurrencyRef>
+    <PrivateNote>Voided</PrivateNote>
+    <Line>
+      <Id>1</Id>
+      <LineNum>1</LineNum>
+      <Description>Plush Baby Doll</Description>
+      <Amount>50.00</Amount>
+      <DetailType>SalesItemLineDetail</DetailType>
+      <SalesItemLineDetail>
+        <ItemRef name="Sales">1</ItemRef>
+        <UnitPrice>50</UnitPrice>
+        <Qty>1</Qty>
+        <TaxCodeRef>NON</TaxCodeRef>
+      </SalesItemLineDetail>
+    </Line>
+    <Line>
+      <Amount>50.00</Amount>
+      <DetailType>SubTotalLineDetail</DetailType>
+      <SubTotalLineDetail />
+    </Line>
+    <CustomerRef name="Sunset Bakery">2</CustomerRef>
+    <CustomerMemo>Message to Customer</CustomerMemo>
+    <BillAddr>
+      <Id>6</Id>
+      <Line1>Rebecca Clark</Line1>
+      <Line2>Sunset Bakery</Line2>
+      <Line3>1040 East Tasman Drive.</Line3>
+      <Line4>Los Angeles, CA  91123 USA</Line4>
+      <Lat>34.1426959</Lat>
+      <Long>-118.1568847</Long>
+    </BillAddr>
+    <ShipAddr>
+      <Id>3</Id>
+      <Line1>1040 East Tasman Drive.</Line1>
+      <City>Los Angeles</City>
+      <Country>USA</Country>
+      <CountrySubDivisionCode>CA</CountrySubDivisionCode>
+      <PostalCode>91123</PostalCode>
+      <Lat>33.739466</Lat>
+      <Long>-118.0395574</Long>
+    </ShipAddr>
+    <SalesTermRef>2</SalesTermRef>
+    <DueDate>2013-11-30</DueDate>
+    <TotalAmt>50.00</TotalAmt>
+    <ApplyTaxAfterDiscount>false</ApplyTaxAfterDiscount>
+    <PrintStatus>NotSet</PrintStatus>
+    <EmailStatus>NotSet</EmailStatus>
+    <Balance>50.00</Balance>
+    <Deposit>0</Deposit>
+    <AllowIPNPayment>false</AllowIPNPayment>
+    <AllowOnlinePayment>false</AllowOnlinePayment>
+    <AllowOnlineCreditCardPayment>false</AllowOnlineCreditCardPayment>
+    <AllowOnlineACHPayment>false</AllowOnlineACHPayment>
+  </Invoice>
+</IntuitResponse>

--- a/spec/fixtures/sales_receipt_void_success_response.xml
+++ b/spec/fixtures/sales_receipt_void_success_response.xml
@@ -1,0 +1,93 @@
+<IntuitResponse xmlns="http://schema.intuit.com/finance/v3" time="2013-12-10T12:38:26.908-08:00">
+  <SalesReceipt domain="QBO" sparse="false">
+    <Id>2</Id>
+    <SyncToken>0</SyncToken>
+    <MetaData>
+      <CreateTime>2013-12-10T05:35:42-08:00</CreateTime>
+      <LastUpdatedTime>2013-12-10T05:35:42-08:00</LastUpdatedTime>
+    </MetaData>
+    <DocNumber>1002</DocNumber>
+    <TxnDate>2013-12-10</TxnDate>
+    <PrivateNote>Voided</PrivateNote>
+    <CurrencyRef name="Brazilian Real">BRL</CurrencyRef>
+    <Line>
+      <Id>1</Id>
+      <LineNum>1</LineNum>
+      <Amount>10.00</Amount>
+      <DetailType>SalesItemLineDetail</DetailType>
+      <SalesItemLineDetail>
+        <ItemRef name="Sales">1</ItemRef>
+        <UnitPrice>10</UnitPrice>
+        <Qty>1</Qty>
+      </SalesItemLineDetail>
+    </Line>
+    <Line>
+      <Amount>10.00</Amount>
+      <DetailType>SubTotalLineDetail</DetailType>
+      <SubTotalLineDetail/>
+    </Line>
+    <CustomerRef name="Luis Braga">1</CustomerRef>
+    <CustomerMemo>memo!</CustomerMemo>
+    <GlobalTaxCalculation>NotApplicable</GlobalTaxCalculation>
+    <TotalAmt>10.00</TotalAmt>
+    <PrintStatus>NotSet</PrintStatus>
+    <EmailStatus>NotSet</EmailStatus>
+    <Balance>0</Balance>
+    <DepositToAccountRef name="Cash and cash equivalents">28</DepositToAccountRef>
+  </SalesReceipt>
+  <SalesReceipt domain="QBO" sparse="false">
+    <Id>1</Id>
+    <SyncToken>1</SyncToken>
+    <MetaData>
+      <CreateTime>2013-12-10T05:27:10-08:00</CreateTime>
+      <LastUpdatedTime>2013-12-10T05:27:26-08:00</LastUpdatedTime>
+    </MetaData>
+    <DocNumber>1001</DocNumber>
+    <TxnDate>2013-12-10</TxnDate>
+    <CurrencyRef name="Brazilian Real">BRL</CurrencyRef>
+    <Line>
+      <Id>1</Id>
+      <LineNum>1</LineNum>
+      <Description>Games</Description>
+      <Amount>10.00</Amount>
+      <DetailType>SalesItemLineDetail</DetailType>
+      <SalesItemLineDetail>
+        <ItemRef name="Sales">1</ItemRef>
+        <UnitPrice>10</UnitPrice>
+        <Qty>1</Qty>
+      </SalesItemLineDetail>
+    </Line>
+    <Line>
+      <Amount>10.00</Amount>
+      <DetailType>SubTotalLineDetail</DetailType>
+      <SubTotalLineDetail/>
+    </Line>
+    <CustomerRef name="Vanessa Feitosa">2</CustomerRef>
+    <BillAddr>
+      <Id>4</Id>
+      <Line1>Vanessa Feitosa</Line1>
+      <Line2>Rua Jorn Helder Feitosa</Line2>
+      <Line3>Bethesda  22000 US</Line3>
+      <Lat>INVALID</Lat>
+      <Long>INVALID</Long>
+    </BillAddr>
+    <ShipAddr>
+      <Id>3</Id>
+      <Line1>Rua Jorn Helder Feitosa</Line1>
+      <City>Bethesda</City>
+      <Country>US</Country>
+      <PostalCode>22000</PostalCode>
+      <Lat>INVALID</Lat>
+      <Long>INVALID</Long>
+    </ShipAddr>
+    <GlobalTaxCalculation>NotApplicable</GlobalTaxCalculation>
+    <TotalAmt>10.00</TotalAmt>
+    <PrintStatus>NotSet</PrintStatus>
+    <EmailStatus>NotSet</EmailStatus>
+    <BillEmail>
+      <Address>vanessa.feitosa@hotmail.com</Address>
+    </BillEmail>
+    <Balance>0</Balance>
+    <DepositToAccountRef name="Cash and cash equivalents">28</DepositToAccountRef>
+  </SalesReceipt>
+</IntuitResponse>

--- a/spec/lib/quickbooks/service/invoice_spec.rb
+++ b/spec/lib/quickbooks/service/invoice_spec.rb
@@ -134,6 +134,31 @@ describe "Quickbooks::Service::Invoice" do
     response.should == true
   end
 
+  it "can void an Invoice" do
+    model = Quickbooks::Model::Invoice
+    invoice = Quickbooks::Model::Invoice.new
+    invoice.doc_number = "1001"
+    invoice.sync_token = 2
+    invoice.id = 1
+    invoice.customer_id = 3
+    line_item = Quickbooks::Model::InvoiceLineItem.new
+    line_item.amount = 50
+    line_item.description = "Plush Baby Doll"
+    line_item.sales_item! do |detail|
+      detail.unit_price = 50
+      detail.quantity = 1
+      detail.item_id = 1
+      detail.tax_code_id = 'NON'
+    end
+    invoice.line_items << line_item
+
+    xml = fixture("invoice_void_success_response.xml")
+    stub_request(:post, "#{@service.url_for_resource(model::REST_RESOURCE)}?include=void", ["200", "OK"], xml)
+
+    response = @service.void(invoice)
+    response.private_note.should == 'Voided'
+  end
+
   it "can generate an invoice with a discount line item" do
     model = Quickbooks::Model::Invoice
     invoice = Quickbooks::Model::Invoice.new


### PR DESCRIPTION
This adds VOID method for Invoice & SalesReceipt. Pretty much same as Void for Payment model.