### PR TITLE
Allow an invoice to be voided using only the Id and SyncToken

### DIFF
--- a/lib/quickbooks/service/invoice.rb
+++ b/lib/quickbooks/service/invoice.rb
@@ -24,11 +24,10 @@ module Quickbooks
       end
 
       def void(invoice, options = {})
-        raise Quickbooks::InvalidModelException.new(invoice.errors.full_messages.join(',')) unless invoice.valid?
-        xml = invoice.to_xml_ns(options)
-        url = "#{url_for_resource(model::REST_RESOURCE)}?include=void"
+        url = "#{url_for_resource(model::REST_RESOURCE)}?operation=void"
 
-        response = do_http_post(url, valid_xml_document(xml), {})
+        xml = invoice.to_xml_ns(options)
+        response = do_http_post(url, valid_xml_document(xml))
         if response.code.to_i == 200
           model.from_xml(parse_singular_entity_response(model, response.plain_body))
         else

--- a/spec/lib/quickbooks/service/invoice_spec.rb
+++ b/spec/lib/quickbooks/service/invoice_spec.rb
@@ -137,23 +137,11 @@ describe "Quickbooks::Service::Invoice" do
   it "can void an Invoice" do
     model = Quickbooks::Model::Invoice
     invoice = Quickbooks::Model::Invoice.new
-    invoice.doc_number = "1001"
     invoice.sync_token = 2
     invoice.id = 1
-    invoice.customer_id = 3
-    line_item = Quickbooks::Model::InvoiceLineItem.new
-    line_item.amount = 50
-    line_item.description = "Plush Baby Doll"
-    line_item.sales_item! do |detail|
-      detail.unit_price = 50
-      detail.quantity = 1
-      detail.item_id = 1
-      detail.tax_code_id = 'NON'
-    end
-    invoice.line_items << line_item
 
     xml = fixture("invoice_void_success_response.xml")
-    stub_request(:post, "#{@service.url_for_resource(model::REST_RESOURCE)}?include=void", ["200", "OK"], xml)
+    stub_request(:post, "#{@service.url_for_resource(model::REST_RESOURCE)}?operation=void", ["200", "OK"], xml)
 
     response = @service.void(invoice)
     response.private_note.should == 'Voided'


### PR DESCRIPTION
I've made this change to the `Service::Invoice#void` method, that was added by @jozefvaclavik via 339d11765318d14f8a6e41e8dc9aa80965f9e34f, so that it's possible to void an invoice by only passing its `Id` and `SyncToken` values.

The method now uses a URL containing `operation=void` as per the [documentation](https://developer.intuit.com/docs/api/accounting/Invoice) so it's more like the `Service::ServiceCrud#delete_by_query_string` method. Removing the call to `invoice.valid?` means that you no longer have to use a `Model::Invoice` object with a customer reference and at least one line item present.