### PR TITLE
Raise ThrottleExceeded when rate limited

### DIFF
--- a/lib/quickbooks-ruby.rb
+++ b/lib/quickbooks-ruby.rb
@@ -217,6 +217,8 @@ module Quickbooks
   end
   class Forbidden < StandardError;
   end
+  class ThrottleExceeded < Forbidden;
+  end
 
   class ServiceUnavailable < StandardError;
   end

--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -268,7 +268,11 @@ module Quickbooks
         when 401
           raise Quickbooks::AuthorizationFailure
         when 403
-          raise Quickbooks::Forbidden
+          message = parse_intuit_error[:message]
+          if message.include?('ThrottleExceeded')
+            raise Quickbooks::ThrottleExceeded, message
+          end
+          raise Quickbooks::Forbidden, message
         when 400, 500
           parse_and_raise_exception(options)
         when 503, 504

--- a/quickbooks-ruby.gemspec
+++ b/quickbooks-ruby.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'oauth', '0.4.7'
   gem.add_dependency 'roxml', '3.3.1'
   gem.add_dependency 'nokogiri'  # promiscuous mode
-  gem.add_dependency 'activemodel', '< 5.0.0'
+  gem.add_dependency 'activemodel', '< 6.0.0'
   gem.add_dependency 'multipart-post' # promiscuous mode
 
   gem.add_development_dependency 'rake', '10.1.0'

--- a/quickbooks-ruby.gemspec
+++ b/quickbooks-ruby.gemspec
@@ -17,7 +17,12 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'oauth', '0.4.7'
   gem.add_dependency 'roxml', '3.3.1'
   gem.add_dependency 'nokogiri'  # promiscuous mode
-  gem.add_dependency 'activemodel', '< 6.0.0'
+  # ActiveModel 5.0 requires ruby 2.2.2 or greater
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
+    gem.add_dependency 'activemodel', '< 6.0.0'
+  else
+    gem.add_dependency 'activemodel', '< 5.0.0'
+  end
   gem.add_dependency 'multipart-post' # promiscuous mode
 
   gem.add_development_dependency 'rake', '10.1.0'

--- a/spec/fixtures/throttle_exceeded_error.xml
+++ b/spec/fixtures/throttle_exceeded_error.xml
@@ -1,0 +1,8 @@
+<IntuitResponse time="2016-10-27T15:07:56.120-07:00" xmlns="http://schema.intuit.com/finance/v3">
+  <Fault type="SERVICE">
+    <Error code="3001">
+      <Message>message=ThrottleExceeded; errorCode=003001; statusCode=403</Message>
+      <Detail>The request limit was reached.  Try again later</Detail>
+    </Error>
+  </Fault>
+</IntuitResponse>

--- a/spec/lib/quickbooks/service/base_service_spec.rb
+++ b/spec/lib/quickbooks/service/base_service_spec.rb
@@ -83,6 +83,13 @@ describe Quickbooks::Service::BaseService do
       expect { @service.send(:check_response, response) }.to raise_error(Quickbooks::Forbidden)
     end
 
+    it "should raise ThrottleExceeded on HTTP 403 with appropriate message" do
+      xml = fixture('throttle_exceeded_error.xml')
+
+      response = Struct.new(:code, :plain_body).new(403, xml)
+      expect { @service.send(:check_response, response) }.to raise_error(Quickbooks::ThrottleExceeded)
+    end
+
     it "should raise ServiceUnavailable on HTTP 503 and 504" do
       xml = fixture('generic_error.xml')
 


### PR DESCRIPTION
Fixes #338. 

Let me know what you think about this. It should be totally backwards compatible but would give a easy way to retry when rate limited. Here's how I'm using it:

``` rb
  def save_with_throttling qbo_record
    tries ||= 3
    nap_time = rand(15..30)

    connection.quickbooks.save!(qbo_record)
  rescue Quickbooks::ThrottleExceeded
    if (tries -= 1) > 0
      logger.info "Hit the rate limit, napping for #{nap_time} seconds"
      sleep nap_time
      retry
    else
      logger.info "Made 3 tries to avoid the rate limit. Aborting"
      raise
    end
  end
```

It's similar to what was suggested in #92 but won't retry on unrelated errors.
