### PR TITLE
Added exception handling for new 429 too many requests throttling.

### DIFF
--- a/lib/quickbooks-ruby.rb
+++ b/lib/quickbooks-ruby.rb
@@ -214,20 +214,13 @@ module Quickbooks
     end
   end # << self
 
-  class InvalidModelException < StandardError;
-  end
-
-  class AuthorizationFailure < StandardError;
-  end
-  class Forbidden < StandardError;
-  end
-  class ThrottleExceeded < Forbidden;
-  end
-
-  class ServiceUnavailable < StandardError;
-  end
-  class MissingRealmError < StandardError;
-  end
+  class InvalidModelException < StandardError; end
+  class AuthorizationFailure < StandardError; end
+  class Forbidden < StandardError; end
+  class ThrottleExceeded < Forbidden; end
+  class TooManyRequests < StandardError; end
+  class ServiceUnavailable < StandardError; end
+  class MissingRealmError < StandardError; end
 
   class IntuitRequestException < StandardError
     attr_accessor :message, :code, :detail, :type, :request_xml, :request_json

--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -275,6 +275,9 @@ module Quickbooks
           raise Quickbooks::Forbidden, message
         when 400, 500
           parse_and_raise_exception(options)
+        when 429
+          message = parse_intuit_error[:message]
+          raise Quickbooks::TooManyRequests, message
         when 503, 504
           raise Quickbooks::ServiceUnavailable
         else

--- a/spec/fixtures/too_many_requests_error.xml
+++ b/spec/fixtures/too_many_requests_error.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<IntuitResponse time="2016-12-07T15:27:09.527-08:00" xmlns="http://schema.intuit.com/finance/v3">
+  <Fault type="SERVICE">
+    <Error code="3001">
+      <Message>message=ThrottleExceeded; errorCode=003001; statusCode=429</Message>
+      <Detail>The request limit was reached.  Try again later</Detail>
+    </Error>
+  </Fault>
+</IntuitResponse>

--- a/spec/lib/quickbooks/service/base_service_spec.rb
+++ b/spec/lib/quickbooks/service/base_service_spec.rb
@@ -90,6 +90,16 @@ describe Quickbooks::Service::BaseService do
       expect { @service.send(:check_response, response) }.to raise_error(Quickbooks::ThrottleExceeded)
     end
 
+    it "should raise TooManyRequests on HTTP 429 with appropriate message" do
+      xml = fixture('too_many_requests_error.xml')
+      message = Nokogiri::XML::Document.parse(xml) do |config|
+        config.noblanks
+      end.css('Message').text
+
+      response = Struct.new(:code, :plain_body).new(429, xml)
+      expect { @service.send(:check_response, response) }.to raise_error(Quickbooks::TooManyRequests, message)
+    end
+
     it "should raise ServiceUnavailable on HTTP 503 and 504" do
       xml = fixture('generic_error.xml')
 


### PR DESCRIPTION
QBO has added 429 errors for the new throttling they have implemented. Not sure if it is active in production yet, but from what we've seen it is in sandbox so we were able to generate the error properly. 

Here is a blog post with the announcement from August 8, 2016: 
https://developer.intuit.com/hub/blog/2016/08/08/idg-concurrent-api-use-changes-coming-soon

This ticket adds the 429 handling (with a spec). 