### PR TITLE
Service.all returns nil if no elements exist, should return []

### DIFF
--- a/lib/quickbooks/service/service_crud.rb
+++ b/lib/quickbooks/service/service_crud.rb
@@ -12,7 +12,7 @@ module Quickbooks
         self.query_in_batches(object_query, options) do |batch|
           collection << batch.entries
         end
-        collection.flatten!
+        collection.flatten
       end
 
       def query_in_batches(object_query=nil, options={})


### PR DESCRIPTION
The flatten! method converts an empty array to nil.  Use flatten to return [] instead.