### PR TITLE
Add more exceptions for HTTP errors

### DIFF
--- a/lib/quickbooks-ruby.rb
+++ b/lib/quickbooks-ruby.rb
@@ -218,6 +218,7 @@ module Quickbooks
   class AuthorizationFailure < StandardError; end
   class Forbidden < StandardError; end
   class NotFound < StandardError; end
+  class RequestTooLarge < StandardError; end
   class ThrottleExceeded < Forbidden; end
   class TooManyRequests < StandardError; end
   class ServiceUnavailable < StandardError; end

--- a/lib/quickbooks-ruby.rb
+++ b/lib/quickbooks-ruby.rb
@@ -217,6 +217,7 @@ module Quickbooks
   class InvalidModelException < StandardError; end
   class AuthorizationFailure < StandardError; end
   class Forbidden < StandardError; end
+  class NotFound < StandardError; end
   class ThrottleExceeded < Forbidden; end
   class TooManyRequests < StandardError; end
   class ServiceUnavailable < StandardError; end

--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -275,6 +275,8 @@ module Quickbooks
           raise Quickbooks::Forbidden, message
         when 404
           raise Quickbooks::NotFound
+        when 413
+          raise Quickbooks::RequestTooLarge
         when 400, 500
           parse_and_raise_exception(options)
         when 429

--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -273,6 +273,8 @@ module Quickbooks
             raise Quickbooks::ThrottleExceeded, message
           end
           raise Quickbooks::Forbidden, message
+        when 404
+          raise Quickbooks::NotFound
         when 400, 500
           parse_and_raise_exception(options)
         when 429

--- a/spec/lib/quickbooks/service/base_service_spec.rb
+++ b/spec/lib/quickbooks/service/base_service_spec.rb
@@ -108,6 +108,27 @@ describe Quickbooks::Service::BaseService do
       expect { @service.send(:check_response, response) }.to raise_error(Quickbooks::NotFound)
     end
 
+    it "should raise NotFound on HTTP 404" do
+      html = <<-HTML
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+<html>
+  <head>
+    <title>413 Request Entity Too Large</title>
+  </head>
+  <body>
+    <h1>Request Entity Too Large</h1>
+    The requested resource<br />
+    /v3/company/123145730715194/batch<br />
+    does not allow request data with POST requests, or the amount of data provided in
+    the request exceeds the capacity limit.
+  </body>
+</html>
+      HTML
+
+      response = Struct.new(:code, :plain_body).new(413, html)
+      expect { @service.send(:check_response, response) }.to raise_error(Quickbooks::RequestTooLarge)
+    end
+
     it "should raise TooManyRequests on HTTP 429 with appropriate message" do
       xml = fixture('too_many_requests_error.xml')
       message = Nokogiri::XML::Document.parse(xml) do |config|

--- a/spec/lib/quickbooks/service/base_service_spec.rb
+++ b/spec/lib/quickbooks/service/base_service_spec.rb
@@ -90,6 +90,24 @@ describe Quickbooks::Service::BaseService do
       expect { @service.send(:check_response, response) }.to raise_error(Quickbooks::ThrottleExceeded)
     end
 
+    it "should raise NotFound on HTTP 404" do
+      html = <<-HTML
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+<html>
+  <head>
+    <title>404 Not Found</title>
+  </head>
+  <body>
+    <h1>Not Found</h1>
+    <p>The requested URL /v3/company/1413511890/query was not found on this server.</p>
+  </body>
+</html>
+      HTML
+
+      response = Struct.new(:code, :plain_body).new(404, html)
+      expect { @service.send(:check_response, response) }.to raise_error(Quickbooks::NotFound)
+    end
+
     it "should raise TooManyRequests on HTTP 429 with appropriate message" do
       xml = fixture('too_many_requests_error.xml')
       message = Nokogiri::XML::Document.parse(xml) do |config|


### PR DESCRIPTION
This adds a couple more exceptions for HTTP errors I've been seeing sporadically.

Fixes:
- #361
- #363