### PR TITLE
add entity as reference

### DIFF
--- a/lib/quickbooks/model/deposit_line_detail.rb
+++ b/lib/quickbooks/model/deposit_line_detail.rb
@@ -2,7 +2,7 @@ module Quickbooks
   module Model
     class DepositLineDetail < BaseModel
 
-      xml_accessor :entity, :from => 'Entity', :as => BaseReference
+      xml_accessor :entity_ref, :from => 'Entity', :as => BaseReference
       xml_accessor :class_ref, :from => 'ClassRef', :as => BaseReference
       xml_accessor :account_ref, :from => 'AccountRef', :as => BaseReference
       xml_accessor :payment_method_ref, :from => 'PaymentMethodRef', :as => BaseReference
@@ -10,7 +10,7 @@ module Quickbooks
       xml_accessor :txn_type, :from => 'TxnType'
       xml_accessor :custom_fields, :from => 'CustomField', :as => [CustomField]
 
-      reference_setters :class_ref, :account_ref, :payment_method_ref
+      reference_setters :class_ref, :account_ref, :payment_method_ref, :entity_ref
 
     end
   end

--- a/spec/lib/quickbooks/model/deposit_spec.rb
+++ b/spec/lib/quickbooks/model/deposit_spec.rb
@@ -17,9 +17,9 @@ describe "Quickbooks::Model::Deposit" do
     deposit.total.should eq(200.0)
     deposit.currency_ref.value.should == 'USD'
     deposit.exchange_rate.should be_nil
-    deposit.line_items[1].deposit_line_detail.entity.type.should == 'CUSTOMER'
-    deposit.line_items[1].deposit_line_detail.entity.name.should == 'Nicole Tang'
-    deposit.line_items[1].deposit_line_detail.entity.value.should == '58'
+    deposit.line_items[1].deposit_line_detail.entity_ref.type.should == 'CUSTOMER'
+    deposit.line_items[1].deposit_line_detail.entity_ref.name.should == 'Nicole Tang'
+    deposit.line_items[1].deposit_line_detail.entity_ref.value.should == '58'
 
     line_item1 = deposit.line_items[0]
     line_item1.id.should be_nil


### PR DESCRIPTION
`DepositLineDetail.entity` should act as a reference as well.
Now, usage is:
`detail.entity = Quickbooks::Model::BaseReference(id)` as opposite to `detail.entity_id = id`