### PR TITLE
Fix reference setters for fields without _ref

### DIFF
--- a/lib/quickbooks/model/base_model.rb
+++ b/lib/quickbooks/model/base_model.rb
@@ -86,7 +86,8 @@ module Quickbooks
           references = args.empty? ? reference_attrs : args
 
           references.each do |attribute|
-            method_name = "#{attribute.to_s.gsub('_ref', '_id')}=".to_sym
+            field_name = attribute.slice(0, attribute.rindex('_ref'))
+            method_name = "#{field_name}_id=".to_sym
             unless instance_methods(false).include?(method_name)
               method_definition = <<-METH
               def #{method_name}(id)

--- a/lib/quickbooks/model/base_model.rb
+++ b/lib/quickbooks/model/base_model.rb
@@ -86,7 +86,8 @@ module Quickbooks
           references = args.empty? ? reference_attrs : args
 
           references.each do |attribute|
-            field_name = attribute.slice(0, attribute.rindex('_ref'))
+            last_index = attribute.rindex('_ref')
+            field_name = !last_index.nil? ? attribute.slice(0, last_index) : attribute
             method_name = "#{field_name}_id=".to_sym
             unless instance_methods(false).include?(method_name)
               method_definition = <<-METH

--- a/lib/quickbooks/model/base_model.rb
+++ b/lib/quickbooks/model/base_model.rb
@@ -86,8 +86,8 @@ module Quickbooks
           references = args.empty? ? reference_attrs : args
 
           references.each do |attribute|
-            last_index = attribute.rindex('_ref')
-            field_name = !last_index.nil? ? attribute.slice(0, last_index) : attribute
+            last_index = attribute.to_s.rindex('_ref')
+            field_name = !last_index.nil? ? attribute.to_s.slice(0, last_index) : attribute
             method_name = "#{field_name}_id=".to_sym
             unless instance_methods(false).include?(method_name)
               method_definition = <<-METH


### PR DESCRIPTION
This is a fix for my previous commit

1. replace only the last occurrence of `_ref`, and non if not found
2. append `_id` as a name, even if `_ref` is not found