### PR TITLE
Exposing Memo field under PurchaseOrder model

### DIFF
--- a/lib/quickbooks/model/purchase_order.rb
+++ b/lib/quickbooks/model/purchase_order.rb
@@ -16,6 +16,7 @@ module Quickbooks
       xml_accessor :txn_date, :from => 'TxnDate', :as => Date
       xml_accessor :custom_fields, :from => 'CustomField', :as => [CustomField]
       xml_accessor :private_note, :from => 'PrivateNote'
+      xml_accessor :memo, :from => 'Memo'
 
       xml_accessor :linked_transactions, :from => 'LinkedTxn', :as => [LinkedTransaction]
       xml_accessor :line_items, :from => 'Line', :as => [PurchaseLineItem]


### PR DESCRIPTION
It exists in the Quickbooks XML already, adding it to the model to be able to set/get it.