### PR TITLE
Raising on invalid OAuth Access Token object type

### DIFF
--- a/lib/quickbooks-ruby.rb
+++ b/lib/quickbooks-ruby.rb
@@ -240,4 +240,10 @@ module Quickbooks
     end
   end
 
+  class InvalidOauthAccessTokenObject < StandardError
+    def initialize(access_token)
+      super("Expected access token to be an instance of OAuth::AccessToken or OAuth2::AccessToken, got #{access_token.class}.")
+    end
+  end
+
 end

--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -273,6 +273,8 @@ module Quickbooks
           @oauth.get(url, headers)
         elsif oauth_v2?
           @oauth.get(url, headers: headers, raise_errors: false)
+        else
+          raise InvalidOauthAccessTokenObject.new(@oauth)
         end
       end
 
@@ -281,6 +283,8 @@ module Quickbooks
           @oauth.post(url, body, headers)
         elsif oauth_v2?
           @oauth.post(url, headers: headers, body: body, raise_errors: false)
+        else
+          raise InvalidOauthAccessTokenObject.new(@oauth)
         end
       end
 
@@ -289,6 +293,8 @@ module Quickbooks
                          oauth.post_with_multipart(url, body, headers)
                        elsif oauth_v2?
                          oauth.post_with_multipart(url, headers: headers, body: body, raise_errors: false)
+                       else
+                         raise InvalidOauthAccessTokenObject.new(@oauth)
                        end
         response = Quickbooks::Service::Responses::OAuthHttpResponse.wrap(raw_response)
         check_response(response, :request => body)


### PR DESCRIPTION
I created this PR to prevent a wrong or missing access token initialization.

If for any reason `@oauth` was not an instance of `OAuth::AccessToken` or `OAuth2::AccessToken` it would just not fire the request, keep going and failing on the response parsing without any clue of what went actually wrong.