### PR TITLE
add handling for multipart request logging

### DIFF
--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -363,7 +363,23 @@ module Quickbooks
         if is_json?
           log(body.inspect)
         else
-          log(log_xml(body))
+          #multipart request for uploads arrive here in a Hash with UploadIO vals
+          if body.is_a?(Hash)
+            body.each do |k,v|
+              log('BODY PART:')
+              val_content = v.inspect
+              if v.is_a?(UploadIO)
+                if v.content_type == 'application/xml'
+                  if v.io.is_a?(StringIO)
+                    val_content = log_xml(v.io.string)
+                  end
+                end
+              end
+              log("#{k}: #{val_content}")
+            end
+          else
+            log(log_xml(body))
+          end
         end
       end
 


### PR DESCRIPTION
When `Quickbooks.log = true` is set, error like the following is logged instead of info for `Quickbooks::Service::Upload#upload`:
```
I, [2017-10-30T16:12:41.992193 #30281]  INFO -- : ------ QUICKBOOKS-RUBY REQUEST ------
I, [2017-10-30T16:12:41.992248 #30281]  INFO -- : METHOD = upload
I, [2017-10-30T16:12:41.992266 #30281]  INFO -- : RESOURCE = https://sandbox-quickbooks.api.intuit.com/v3/company/193514579900464/upload
I, [2017-10-30T16:12:41.992282 #30281]  INFO -- : REQUEST BODY:
I, [2017-10-30T16:12:41.993366 #30281]  INFO -- : no implicit conversion of Hash into String (TypeError)
~/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/gems/nokogiri-1.8.1/lib/nokogiri/xml/document.rb:62:in `read_memory'
~/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/gems/nokogiri-1.8.1/lib/nokogiri/xml/document.rb:62:in `parse'
~/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/gems/nokogiri-1.8.1/lib/nokogiri/xml.rb:34:in `XML'
~/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/bundler/gems/quickbooks-ruby-fbe96496fa40/lib/quickbooks/util/logging.rb:10:in `log_xml'
~/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/bundler/gems/quickbooks-ruby-fbe96496fa40/lib/quickbooks/service/base_service.rb:366:in `log_request_body'
~/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/bundler/gems/quickbooks-ruby-fbe96496fa40/lib/quickbooks/service/base_service.rb:254:in `do_http'
~/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/bundler/gems/quickbooks-ruby-fbe96496fa40/lib/quickbooks/service/base_service.rb:234:in `do_http_file_upload'
~/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/bundler/gems/quickbooks-ruby-fbe96496fa40/lib/quickbooks/service/upload.rb:13:in `upload'
```

the exception is handled, so non-crucial, but this will replace a slightly alarming stack trace with dumping of textual parts of multipart request body.

output now is:
```
I, [2017-10-31T14:19:44.754127 #48542]  INFO -- : BODY PART:
I, [2017-10-31T14:19:44.754180 #48542]  INFO -- : file_content_0: #<UploadIO:0x007f9b57320c68 @content_type="application/pdf", @original_filename="1509477582693.pdf", @local_path=".../tmp/1509477582693.pdf", @io=#<File:.../tmp/pieces/piece_contents_bitonal_normal-1509477582693.pdf>, @opts={}>
I, [2017-10-31T14:19:44.754204 #48542]  INFO -- : BODY PART:
I, [2017-10-31T14:19:44.754481 #48542]  INFO -- : file_metadata_0: <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<Attachable xmlns="http://schema.intuit.com/finance/v3" sparse="false">
<AttachableRef>
<EntityRef type="Payment">180</EntityRef>
</AttachableRef>
<FileName>the-1509477584752.pdf</FileName>
<ContentType>application/pdf</ContentType>
<Note>an upload, y'all</Note>
</Attachable>
```

