### PR TITLE
Allow roxml 4.0.0

### DIFF
--- a/quickbooks-ruby.gemspec
+++ b/quickbooks-ruby.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.files = Dir['lib/**/*']
 
   gem.add_dependency 'oauth', '0.4.7'
-  gem.add_dependency 'roxml', '3.3.1'
+  gem.add_dependency 'roxml', '>= 3.3.1', '< 4.1'
   gem.add_dependency 'nokogiri'  # promiscuous mode
   gem.add_dependency 'activemodel' # promiscuous mode
   gem.add_dependency 'multipart-post' # promiscuous mode


### PR DESCRIPTION
@ruckus Updates dependencies so that `roxml` 4.0 can be used, fixing warnings in new Ruby versions.

```
roxml-3.3.1/lib/roxml/definition.rb:156: warning: constant ::Fixnum is deprecated
```

Ref #386