### PR TITLE
Fix Content-Type in Send Invoice

### DIFF
--- a/lib/quickbooks/service/invoice.rb
+++ b/lib/quickbooks/service/invoice.rb
@@ -9,7 +9,7 @@ module Quickbooks
       def send(invoice, email_address=nil)
         query = email_address.present? ? "?sendTo=#{email_address}" : ""
         url = "#{url_for_resource(model::REST_RESOURCE)}/#{invoice.id}/send#{query}"
-        response = do_http_post(url,{}.to_json)
+        response = do_http_post(url)
         if response.code.to_i == 200
           model.from_xml(parse_singular_entity_response(model, response.plain_body))
         else

--- a/lib/quickbooks/service/invoice.rb
+++ b/lib/quickbooks/service/invoice.rb
@@ -9,7 +9,7 @@ module Quickbooks
       def send(invoice, email_address=nil)
         query = email_address.present? ? "?sendTo=#{email_address}" : ""
         url = "#{url_for_resource(model::REST_RESOURCE)}/#{invoice.id}/send#{query}"
-        response = do_http_post(url)
+        response = do_http_post(url, "", {}, { 'Content-Type' => 'application/octet-stream' })
         if response.code.to_i == 200
           model.from_xml(parse_singular_entity_response(model, response.plain_body))
         else

--- a/lib/quickbooks/service/invoice.rb
+++ b/lib/quickbooks/service/invoice.rb
@@ -9,7 +9,7 @@ module Quickbooks
       def send(invoice, email_address=nil)
         query = email_address.present? ? "?sendTo=#{email_address}" : ""
         url = "#{url_for_resource(model::REST_RESOURCE)}/#{invoice.id}/send#{query}"
-        response = do_http_post(url,'')
+        response = do_http_post(url,{}.to_json)
         if response.code.to_i == 200
           model.from_xml(parse_singular_entity_response(model, response.plain_body))
         else

--- a/lib/quickbooks/service/invoice.rb
+++ b/lib/quickbooks/service/invoice.rb
@@ -9,7 +9,7 @@ module Quickbooks
       def send(invoice, email_address=nil)
         query = email_address.present? ? "?sendTo=#{email_address}" : ""
         url = "#{url_for_resource(model::REST_RESOURCE)}/#{invoice.id}/send#{query}"
-        response = do_http_post(url,{})
+        response = do_http_post(url,'')
         if response.code.to_i == 200
           model.from_xml(parse_singular_entity_response(model, response.plain_body))
         else


### PR DESCRIPTION
According to documentation in https://developer.intuit.com/docs/api/accounting/invoice `Content-Type` for sending Invoice email must be `application/octet-stream`

This PR intends to fix this by sending the correct `Content-Type` in the service call to `do_http_post`

The error I was originally getting was ```NoMethodError: undefined method `bytesize' for #<Hash...```, and after fixing this I started getting `400` status due to the `Content-Type`