### PR TITLE
Add support to follow 302 redirects in do_http

### DIFF
--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -239,7 +239,12 @@ module Quickbooks
           else
             raise "Do not know how to perform that HTTP operation"
           end
-        check_response(response, :request => body)
+
+        if response.code.to_i == 302
+          do_http(method, response['location'], body, headers)
+        else
+          check_response(response, :request => body)
+        end
       end
 
       def add_query_string_to_url(url, params)
@@ -263,8 +268,6 @@ module Quickbooks
           else
             response
           end
-        when 302
-          raise "Unhandled HTTP Redirect"
         when 401
           raise Quickbooks::AuthorizationFailure
         when 403

--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -240,7 +240,7 @@ module Quickbooks
             raise "Do not know how to perform that HTTP operation"
           end
 
-        if response.code.to_i == 302
+        if response.code.to_i == 302 && [:get, :post].include?(method)
           do_http(method, response['location'], body, headers)
         else
           check_response(response, :request => body)
@@ -268,6 +268,8 @@ module Quickbooks
           else
             response
           end
+        when 302
+          raise "Unhandled HTTP Redirect"
         when 401
           raise Quickbooks::AuthorizationFailure
         when 403

--- a/quickbooks-ruby.gemspec
+++ b/quickbooks-ruby.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake', '10.1.0'
   gem.add_development_dependency 'simplecov', '0.7.1'
   gem.add_development_dependency 'rr',     '~> 1.0.2'
-  gem.add_development_dependency 'rspec',  '2.13.0'
+  gem.add_development_dependency 'rspec',  '2.14.1'
   gem.add_development_dependency 'fakeweb', '1.3.0'
 end

--- a/spec/lib/quickbooks/service/access_token_spec.rb
+++ b/spec/lib/quickbooks/service/access_token_spec.rb
@@ -5,7 +5,7 @@ describe Quickbooks::Service::AccessToken do
 
   it "can renew a token" do
     xml = fixture("access_token_200.xml")
-    stub_request(:get, Quickbooks::Service::AccessToken::RENEW_URL, ["200", "OK"], xml, true)
+    stub_request(:get, Quickbooks::Service::AccessToken::RENEW_URL, ["200", "OK"], xml, {}, true)
 
     response = @service.renew
     response.error?.should == false
@@ -14,7 +14,7 @@ describe Quickbooks::Service::AccessToken do
   it "fails to renew if the token has expired" do
     xml = fixture("access_token_270.xml")
 
-    stub_request(:get, Quickbooks::Service::AccessToken::RENEW_URL, ["200", "OK"], xml, true)
+    stub_request(:get, Quickbooks::Service::AccessToken::RENEW_URL, ["200", "OK"], xml, {}, true)
 
     response = @service.renew
     response.error?.should == true
@@ -25,7 +25,7 @@ describe Quickbooks::Service::AccessToken do
   it "fails to renew if the request is out-of-bounds" do
     xml = fixture("access_token_212.xml")
 
-    stub_request(:get, Quickbooks::Service::AccessToken::RENEW_URL, ["200", "OK"], xml, true)
+    stub_request(:get, Quickbooks::Service::AccessToken::RENEW_URL, ["200", "OK"], xml, {}, true)
 
     response = @service.renew
     response.error?.should == true
@@ -36,7 +36,7 @@ describe Quickbooks::Service::AccessToken do
   it "fails to renew if the app is not approved" do
     xml = fixture("access_token_24.xml")
 
-    stub_request(:get, Quickbooks::Service::AccessToken::RENEW_URL, ["200", "OK"], xml, true)
+    stub_request(:get, Quickbooks::Service::AccessToken::RENEW_URL, ["200", "OK"], xml, {}, true)
 
     response = @service.renew
     response.error?.should == true
@@ -46,7 +46,7 @@ describe Quickbooks::Service::AccessToken do
 
   it "can successfully disconnect" do
     xml = fixture("disconnect_200.xml")
-    stub_request(:get, Quickbooks::Service::AccessToken::DISCONNECT_URL, ["200", "OK"], xml, true)
+    stub_request(:get, Quickbooks::Service::AccessToken::DISCONNECT_URL, ["200", "OK"], xml, {}, true)
 
     response = @service.disconnect
     response.error?.should == false
@@ -54,7 +54,7 @@ describe Quickbooks::Service::AccessToken do
 
   it "can fail to disconnect if the auth token is invalid" do
     xml = fixture("disconnect_270.xml")
-    stub_request(:get, Quickbooks::Service::AccessToken::DISCONNECT_URL, ["200", "OK"], xml, true)
+    stub_request(:get, Quickbooks::Service::AccessToken::DISCONNECT_URL, ["200", "OK"], xml, {}, true)
 
     response = @service.disconnect
     response.error?.should == true

--- a/spec/lib/quickbooks/service/account_spec.rb
+++ b/spec/lib/quickbooks/service/account_spec.rb
@@ -5,7 +5,7 @@ describe Quickbooks::Service::Account do
 
   it "can query for accounts" do
     xml = fixture("accounts.xml")
-    stub_request(:get, @service.url_for_query, ["200", "OK"], xml, true)
+    stub_request(:get, @service.url_for_query, ["200", "OK"], xml, {}, true)
 
     accounts = @service.query
     accounts.entries.count.should == 10

--- a/spec/lib/quickbooks/service/attachable_spec.rb
+++ b/spec/lib/quickbooks/service/attachable_spec.rb
@@ -5,7 +5,7 @@ describe Quickbooks::Service::Account do
 
   it "can query for attachables" do
     xml = fixture("attachables.xml")
-    stub_request(:get, @service.url_for_query, ["200", "OK"], xml, true)
+    stub_request(:get, @service.url_for_query, ["200", "OK"], xml, {}, true)
 
     attachables = @service.query
     attachables.entries.count.should == 1
@@ -16,7 +16,7 @@ describe Quickbooks::Service::Account do
 
   it "can create an attachble" do
     xml = fixture("attachable_create_response.xml")
-    stub_request(:post, @service.url_for_resource('attachable'), ["200", "OK"], xml, true)
+    stub_request(:post, @service.url_for_resource('attachable'), ["200", "OK"], xml, {}, true)
 
     attachable = Quickbooks::Model::Attachable.new
     attachable.file_name = "monkey.jpg"

--- a/spec/lib/quickbooks/service/bill_payment_spec.rb
+++ b/spec/lib/quickbooks/service/bill_payment_spec.rb
@@ -52,6 +52,7 @@ describe "Quickbooks::Service::BillPayment" do
                  @service.url_for_resource(resource),
                  ["200", "OK"],
                  fixture("fetch_bill_payment_by_id.xml"),
+                 {},
                  true)
 
     update_response = @service.update(bill_payment, :sparse => true)

--- a/spec/lib/quickbooks/service/class_spec.rb
+++ b/spec/lib/quickbooks/service/class_spec.rb
@@ -59,7 +59,7 @@ describe "Quickbooks::Service::Class" do
     classs.sync_token = 1
     classs.id = 2
     xml = fixture("deleted_class.xml")
-    stub_request(:post, @service.url_for_resource(model::REST_RESOURCE), ["200", "OK"], xml, true)
+    stub_request(:post, @service.url_for_resource(model::REST_RESOURCE), ["200", "OK"], xml, {}, true)
     classs.valid_for_deletion?.should == true
     response = @service.delete(classs)
     response.name.should == "#{classs.name} (Deleted)"

--- a/spec/lib/quickbooks/service/customer_spec.rb
+++ b/spec/lib/quickbooks/service/customer_spec.rb
@@ -79,7 +79,7 @@ describe "Quickbooks::Service::Customer" do
     customer.id = 1
 
     xml = fixture("fetch_customer_by_id.xml")
-    stub_request(:post, @service.url_for_resource(model::REST_RESOURCE), ["200", "OK"], xml, true)
+    stub_request(:post, @service.url_for_resource(model::REST_RESOURCE), ["200", "OK"], xml, {}, true)
 
     customer.valid_for_update?.should == true
     update_response = @service.update(customer, :sparse => true)
@@ -94,7 +94,7 @@ describe "Quickbooks::Service::Customer" do
     customer.id = 1
 
     xml = fixture("deleted_customer.xml")
-    stub_request(:post, @service.url_for_resource(model::REST_RESOURCE), ["200", "OK"], xml, true)
+    stub_request(:post, @service.url_for_resource(model::REST_RESOURCE), ["200", "OK"], xml, {}, true)
 
     customer.valid_for_deletion?.should == true
     response = @service.delete(customer)

--- a/spec/lib/quickbooks/service/department_spec.rb
+++ b/spec/lib/quickbooks/service/department_spec.rb
@@ -56,7 +56,7 @@ describe "Quickbooks::Service::Department" do
     department.sync_token = 1
     department.id = 2
     xml = fixture("deleted_department.xml")
-    stub_request(:post, @service.url_for_resource(model::REST_RESOURCE), ["200", "OK"], xml, true)
+    stub_request(:post, @service.url_for_resource(model::REST_RESOURCE), ["200", "OK"], xml, {}, true)
     department.valid_for_deletion?.should == true
     response = @service.delete(department)
     response.name.should == "#{department.name} (Deleted)"

--- a/spec/lib/quickbooks/service/deposit_spec.rb
+++ b/spec/lib/quickbooks/service/deposit_spec.rb
@@ -48,6 +48,7 @@ describe "Quickbooks::Service::Deposit" do
                  @service.url_for_resource(resource),
                  ["200", "OK"],
                  fixture("fetch_deposit_by_id.xml"),
+                 {},
                  true)
 
     deposit.line_items << Quickbooks::Model::DepositLineItem.new

--- a/spec/lib/quickbooks/service/employee_spec.rb
+++ b/spec/lib/quickbooks/service/employee_spec.rb
@@ -77,7 +77,7 @@ describe "Quickbooks::Service::Employee" do
     employee.sync_token = 1
     employee.id = 2
     xml = fixture("deleted_employee.xml")
-    stub_request(:post, @service.url_for_resource(model::REST_RESOURCE), ["200", "OK"], xml, true)
+    stub_request(:post, @service.url_for_resource(model::REST_RESOURCE), ["200", "OK"], xml, {}, true)
     employee.valid_for_deletion?.should == true
     response = @service.delete(employee)
     response.display_name.should == "#{employee.display_name} (Deleted)"

--- a/spec/lib/quickbooks/service/item_spec.rb
+++ b/spec/lib/quickbooks/service/item_spec.rb
@@ -59,7 +59,7 @@ describe "Quickbooks::Service::Item" do
     item.description = nil
 
     xml = fixture("fetch_item_by_id.xml")
-    stub_request(:post, @service.url_for_resource(model::REST_RESOURCE), ["200", "OK"], xml, true)
+    stub_request(:post, @service.url_for_resource(model::REST_RESOURCE), ["200", "OK"], xml, {}, true)
 
     update_response = @service.update(item, :sparse => true)
     update_response.name.should == 'Plush Baby Doll'
@@ -74,7 +74,7 @@ describe "Quickbooks::Service::Item" do
     item.id = 1
 
     xml = fixture("item_delete_success_response.xml")
-    stub_request(:post, @service.url_for_resource(model::REST_RESOURCE), ["200", "OK"], xml, true)
+    stub_request(:post, @service.url_for_resource(model::REST_RESOURCE), ["200", "OK"], xml, {}, true)
 
     response = @service.delete(item)
     response.active?.should be_nil

--- a/spec/lib/quickbooks/service/payment_method_spec.rb
+++ b/spec/lib/quickbooks/service/payment_method_spec.rb
@@ -66,7 +66,7 @@ module Quickbooks
         payment_method.sync_token = 0
         payment_method.id = 7
         xml = fixture("deleted_payment_method.xml")
-        stub_request(:post, @service.url_for_resource(model::REST_RESOURCE), ["200", "OK"], xml, true)
+        stub_request(:post, @service.url_for_resource(model::REST_RESOURCE), ["200", "OK"], xml, {}, true)
         payment_method.valid_for_deletion?.should == true
         response = @service.delete(payment_method)
         response.name.should == "#{payment_method.name} (Deleted)"

--- a/spec/lib/quickbooks/service/payment_spec.rb
+++ b/spec/lib/quickbooks/service/payment_spec.rb
@@ -47,6 +47,7 @@ describe "Quickbooks::Service::Payment" do
                  @service.url_for_resource(resource),
                  ["200", "OK"],
                  fixture("fetch_payment_by_id.xml"),
+                 {},
                  true)
 
     update_response = @service.update(payment, :sparse => true)

--- a/spec/lib/quickbooks/service/purchase_order_spec.rb
+++ b/spec/lib/quickbooks/service/purchase_order_spec.rb
@@ -8,7 +8,7 @@ describe "Quickbooks::Service::PurchaseOrder" do
     model = Quickbooks::Model::PurchaseOrder
     purchase_order = model.new
     xml = fixture("deleted_purchase_order.xml")
-    stub_request(:post, @service.url_for_resource(model::REST_RESOURCE), ["200", "OK"], xml, false)
+    stub_request(:post, @service.url_for_resource(model::REST_RESOURCE), ["200", "OK"], xml, {}, false)
     expect(@service.delete(purchase_order)).to eq true
 
   end

--- a/spec/lib/quickbooks/service/term_spec.rb
+++ b/spec/lib/quickbooks/service/term_spec.rb
@@ -42,6 +42,7 @@ describe "Quickbooks::Service::Term" do
                  @service.url_for_resource(resource),
                  ["200", "OK"],
                  fixture("fetch_term_by_id.xml"),
+                 {},
                  true)
 
     updated_term = @service.update(term, :sparse => true)

--- a/spec/lib/quickbooks/service/upload_spec.rb
+++ b/spec/lib/quickbooks/service/upload_spec.rb
@@ -5,7 +5,7 @@ describe Quickbooks::Service::Upload do
 
   it "can create an upload" do
     xml = fixture("upload_create_response.xml")
-    stub_request(:post, @service.url_for_resource('upload'), ["200", "OK"], xml, true)
+    stub_request(:post, @service.url_for_resource('upload'), ["200", "OK"], xml, {}, true)
 
     attachable = Quickbooks::Model::Attachable.new
     attachable.file_name = "monkey.jpg"

--- a/spec/lib/quickbooks/service/vendor_spec.rb
+++ b/spec/lib/quickbooks/service/vendor_spec.rb
@@ -78,7 +78,7 @@ describe "Quickbooks::Service::Vendor" do
     vendor.sync_token = 4
     vendor.id = 1129
     xml = fixture("deleted_vendor.xml")
-    stub_request(:post, @service.url_for_resource(model::REST_RESOURCE), ["200", "OK"], xml, true)
+    stub_request(:post, @service.url_for_resource(model::REST_RESOURCE), ["200", "OK"], xml, {}, true)
     vendor.valid_for_deletion?.should == true
     response = @service.delete(vendor)
     response.display_name.should == "#{vendor.display_name} (Deleted)"

--- a/spec/support/net_helpers.rb
+++ b/spec/support/net_helpers.rb
@@ -3,7 +3,7 @@ module NetHelpers
   # +strict+ indicates whether we want to use a regex for a matching URL, which is needed
   # for URLs that use query params. If you don't need use query params
   # than its suggested to use strict = true
-  def stub_request(method, url, status = ["200", "OK"], body = nil, strict = true)
+  def stub_request(method, url, status = ["200", "OK"], body = nil, headers = {}, strict = true)
     if !strict
       if url.is_a?(String)
         url = url.gsub('?', '\?')
@@ -12,7 +12,7 @@ module NetHelpers
     else
       uri = url
     end
-    FakeWeb.register_uri(method, uri, :status => status, :body => body)
+    FakeWeb.register_uri(method, uri, { :status => status, :body => body }.merge(headers))
   end
 end
 

--- a/spec/support/oauth_helpers.rb
+++ b/spec/support/oauth_helpers.rb
@@ -12,9 +12,9 @@ module OauthHelpers
     OAuth::AccessToken.new(oauth_consumer, "token", "secret")
   end
 
-  def construct_service(model)
+  def construct_service(model, access_token=construct_oauth)
     @service = "Quickbooks::Service::#{model.to_s.camelcase}".constantize.new
-    @service.access_token = construct_oauth
+    @service.access_token = access_token
     @service.company_id = "9991111222"
     @service
   end


### PR DESCRIPTION
Recently I have been receiving occasional 302 responses from the QuickBooks API and thus discovered that the gem doesn't follow the redirects. This PR updates `do_http` method in the base service to follow 302s for both GET and POST requests, as well as adding tests for said method. It also updates `stub_request` to support headers being provided, and updates all uses of it to handle that.

As part of this PR I've also updated `rspec` from 2.13 to 2.14.1. I needed `have_received` for the specs, *and* `2.14.1` is the most up-to-date version before deprecation notices appear regarding version 3.