### PR TITLE
Add exception for unhandled redirect instead of raising a RuntimeError

### DIFF
--- a/lib/quickbooks-ruby.rb
+++ b/lib/quickbooks-ruby.rb
@@ -226,6 +226,7 @@ module Quickbooks
   class TooManyRequests < StandardError; end
   class ServiceUnavailable < StandardError; end
   class MissingRealmError < StandardError; end
+  class UnhandledHttpRedirect < StandardError; end
 
   class IntuitRequestException < StandardError
     attr_accessor :message, :code, :detail, :type, :request_xml, :request_json

--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -269,7 +269,7 @@ module Quickbooks
             response
           end
         when 302
-          raise "Unhandled HTTP Redirect"
+          raise Quickbooks::UnhandledHttpRedirect
         when 401
           raise Quickbooks::AuthorizationFailure
         when 403

--- a/spec/lib/quickbooks/service/base_service_spec.rb
+++ b/spec/lib/quickbooks/service/base_service_spec.rb
@@ -145,7 +145,7 @@ describe Quickbooks::Service::BaseService do
           end
 
           it 'raises an error' do
-            expect { @service.send(:do_http, :upload, base_url, nil, headers) }.to raise_error(RuntimeError)
+            expect { @service.send(:do_http, :upload, base_url, nil, headers) }.to raise_error(Quickbooks::UnhandledHttpRedirect)
           end
         end
       end


### PR DESCRIPTION
Having to catch a runtime error and inspect its message to match against an unhandled redirect is causing some pain for us (and there have been a lot of unhandled HTTP redirect errors today). This could be a breaking change for some people but I thought I'd put it out there as an idea to see if it's worth implementing into the gem. 