### PR TITLE
Treat http 502 as ServiceUnavailable instead of `RuntimeError`

### DIFF
--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -289,7 +289,7 @@ module Quickbooks
         when 429
           message = parse_intuit_error[:message]
           raise Quickbooks::TooManyRequests, message
-        when 503, 504
+        when 502, 503, 504
           raise Quickbooks::ServiceUnavailable
         else
           raise "HTTP Error Code: #{status}, Msg: #{response.plain_body}"

--- a/spec/lib/quickbooks/service/base_service_spec.rb
+++ b/spec/lib/quickbooks/service/base_service_spec.rb
@@ -244,8 +244,11 @@ describe Quickbooks::Service::BaseService do
       expect { @service.send(:check_response, response) }.to raise_error(Quickbooks::TooManyRequests, message)
     end
 
-    it "should raise ServiceUnavailable on HTTP 503 and 504" do
+    it "should raise ServiceUnavailable on HTTP 502, 503 and 504" do
       xml = fixture('generic_error.xml')
+
+      response = Struct.new(:code, :plain_body).new(502, xml)
+      expect { @service.send(:check_response, response) }.to raise_error(Quickbooks::ServiceUnavailable)
 
       response = Struct.new(:code, :plain_body).new(503, xml)
       expect { @service.send(:check_response, response) }.to raise_error(Quickbooks::ServiceUnavailable)


### PR DESCRIPTION
We have come across http 502 (Bad Gateway), and think it might be sensible to treat http 502 as a `Quickbooks::ServiceUnavailable` instead of generic `RuntimeError` with msg "HTTP Error Code: 502 ...".  Not sure if this will be a breaking change for some people, but perhaps it's sufficiently similar to http 504 in terms of error handling.