### PR TITLE
Fixes #434

### DIFF
--- a/lib/quickbooks/model/report.rb
+++ b/lib/quickbooks/model/report.rb
@@ -37,13 +37,9 @@ module Quickbooks
         row_node.elements.map.with_index do |el, i|
           value = el.attr('value')
 
-          if i.zero? # Return the first column as a string, its the label.
-            value
-          elsif value.blank?
-            nil
-          else
-            BigDecimal(value)
-          end
+          next nil if value.blank?
+          next value if value.to_s.match(/^\d+$|^\d+.\d+$|^-\d+|^-\d+.\d+$|^.\d+$/).nil?
+          BigDecimal(value)
         end
       end
 

--- a/spec/fixtures/age_payable_detail.xml
+++ b/spec/fixtures/age_payable_detail.xml
@@ -1,0 +1,142 @@
+<Report xmlns="http://schema.intuit.com/finance/v3">
+  <Header>
+    <Time>2018-07-13T09:58:36-07:00</Time>
+    <ReportName>AgedPayableDetail</ReportName>
+    <DateMacro>today</DateMacro>
+    <StartPeriod>2018-07-13</StartPeriod>
+    <EndPeriod>2018-07-13</EndPeriod>
+    <Currency>USD</Currency>
+    <Option>
+      <Name>report_date</Name>
+      <Value>2018-07-13</Value>
+    </Option>
+    <Option>
+      <Name>NoReportData</Name>
+      <Value>false</Value>
+    </Option>
+  </Header>
+  <Columns>
+    <Column>
+      <ColTitle>Date</ColTitle>
+      <ColType>Date</ColType>
+      <MetaData>
+        <Name>ColKey</Name>
+        <Value>tx_date</Value>
+      </MetaData>
+    </Column>
+    <Column>
+      <ColTitle>Transaction Type</ColTitle>
+      <ColType>String</ColType>
+      <MetaData>
+        <Name>ColKey</Name>
+        <Value>txn_type</Value>
+      </MetaData>
+    </Column>
+    <Column>
+      <ColTitle>Num</ColTitle>
+      <ColType>String</ColType>
+      <MetaData>
+        <Name>ColKey</Name>
+        <Value>doc_num</Value>
+      </MetaData>
+    </Column>
+    <Column>
+      <ColTitle>Vendor</ColTitle>
+      <ColType>String</ColType>
+      <MetaData>
+        <Name>ColKey</Name>
+        <Value>vend_name</Value>
+      </MetaData>
+    </Column>
+    <Column>
+      <ColTitle>Due Date</ColTitle>
+      <ColType>Date</ColType>
+      <MetaData>
+        <Name>ColKey</Name>
+        <Value>due_date</Value>
+      </MetaData>
+    </Column>
+    <Column>
+      <ColTitle>Past Due</ColTitle>
+      <ColType>String</ColType>
+      <MetaData>
+        <Name>ColKey</Name>
+        <Value>past_due</Value>
+      </MetaData>
+    </Column>
+    <Column>
+      <ColTitle>Amount</ColTitle>
+      <ColType>Money</ColType>
+      <MetaData>
+        <Name>ColKey</Name>
+        <Value>subt_neg_amount</Value>
+      </MetaData>
+    </Column>
+    <Column>
+      <ColTitle>Open Balance</ColTitle>
+      <ColType>Money</ColType>
+      <MetaData>
+        <Name>ColKey</Name>
+        <Value>subt_neg_open_bal</Value>
+      </MetaData>
+    </Column>
+  </Columns>
+  <Rows>
+    <Row type="Section">
+      <Header>
+        <ColData value="Text replacment" />
+        <ColData value="" />
+        <ColData value="" />
+        <ColData value="" />
+        <ColData value="" />
+        <ColData value="" />
+        <ColData value="" />
+        <ColData value="" />
+      </Header>
+      <Rows>
+        <Row type="Data">
+          <ColData value="2018-05-18" />
+          <ColData value="Journal Entry" id="963" />
+          <ColData value="1" />
+          <ColData value="Robot" id="85" />
+          <ColData value="2012-04-18" />
+          <ColData value="99999" />
+          <ColData value="-12345678.00" />
+          <ColData value="-12345678.00" />
+        </Row>
+        <Row type="Data">
+          <ColData value="2018-05-18" />
+          <ColData value="Bill" id="962" />
+          <ColData value="" />
+          <ColData value="Robot Parts" id="85" />
+          <ColData value="2016-05-28" />
+          <ColData value="100" />
+          <ColData value="100.00" />
+          <ColData value="100.00" />
+        </Row>
+      </Rows>
+      <Summary>
+        <ColData value="Total" />
+        <ColData value="" />
+        <ColData value="" />
+        <ColData value="" />
+        <ColData value="" />
+        <ColData value="" />
+        <ColData value=".00" />
+        <ColData value=".00" />
+      </Summary>
+    </Row>
+    <Row type="Section">
+      <Summary>
+        <ColData value="TOTAL" />
+        <ColData value="" />
+        <ColData value="" />
+        <ColData value="" />
+        <ColData value="" />
+        <ColData value="" />
+        <ColData value=".00" />
+        <ColData value=".00" />
+      </Summary>
+    </Row>
+  </Rows>
+</Report>

--- a/spec/lib/quickbooks/model/report_spec.rb
+++ b/spec/lib/quickbooks/model/report_spec.rb
@@ -7,6 +7,7 @@ describe Quickbooks::Model::Report do
 
   let(:report) { build_report("balancesheet.xml") }
   let(:report_with_years) { build_report("balance_sheet_with_year_summary.xml") }
+  let(:age_payable_report) { build_report("age_payable_detail.xml") }
 
   describe "#xml" do
     it 'exposes the full xml response' do
@@ -44,6 +45,14 @@ describe Quickbooks::Model::Report do
     it 'works with multiple columns' do
       report_with_years.all_rows[3].should == ['Checking', nil, nil, BigDecimal("1201.00")]
       report_with_years.all_rows[4].should == ['Savings', BigDecimal("19.99"), BigDecimal("19.99"), BigDecimal("819.99")]
+    end
+
+    it 'works with text columns' do
+      age_payable_report.all_rows[0].should == ['Text replacment', nil, nil, nil, nil, nil, nil, nil]
+      age_payable_report.all_rows[1].should == ['2018-05-18', 'Journal Entry', BigDecimal('1'), 'Robot', '2012-04-18', BigDecimal('99999'), BigDecimal('-12345678.00'), BigDecimal('-12345678.00')]
+      age_payable_report.all_rows[2].should == ['2018-05-18', 'Bill', nil, 'Robot Parts', '2016-05-28', BigDecimal('100'), BigDecimal('100'), BigDecimal('100')]
+      age_payable_report.all_rows[3].should == ['Total', nil, nil, nil, nil, nil, BigDecimal('.00'), BigDecimal('.00')]
+      age_payable_report.all_rows[4].should == ['TOTAL', nil, nil, nil, nil, nil, BigDecimal('.00'), BigDecimal('.00')]
     end
   end
 


### PR DESCRIPTION
This will allow reports with multiple strings to render [Example Row](https://github.com/ruckus/quickbooks-ruby/pull/435/files#diff-7ec509edffa99799ffbe734001960ed8R52)

Regex:
^\d+$ - `5`
^\d+.\d+$ - `5.5`
^-\d+ - `-500`
^-\d+.\d+$ - `-5.5`
^.\d+$ - `.55`