### PR TITLE
Validate TimeActivity description length

### DIFF
--- a/lib/quickbooks/model/time_activity.rb
+++ b/lib/quickbooks/model/time_activity.rb
@@ -43,10 +43,11 @@ module Quickbooks
       validates_inclusion_of :name_of, :in => NAMEOF_OPTIONS
       validate :existence_of_employee_ref, :if => Proc.new { |ta| ta.name_of == "Employee" }
       validate :existence_of_vendor_ref, :if => Proc.new { |ta| ta.name_of == "Vendor" }
+      validates :description, length: { maximum: 4000 }
 
       def existence_of_employee_ref
         if employee_ref.nil? || (employee_ref && employee_ref.value == 0)
-          errors.add(:employee_ref, "VendorRef is required and must be a non-zero value.")
+          errors.add(:employee_ref, "EmployeeRef is required and must be a non-zero value.")
         end
       end
 


### PR DESCRIPTION
* Fix validation error typo (`EmployeeRef` was referred to as `VendorRef`)
* Add max length validation to TimeActivity description
  * Per [the TimeActivity docs](https://developer.intuit.com/docs/api/accounting/timeactivity#/id-timeactivityresponse), the maximum character length of the `Description` property is 4000
  * When invalid, the QuickBooks API will respond with:

```js
{
  "Fault": {
    "Error": [
      {
        "Message": "String length is either shorter or longer than supported by specification",
        "Detail": "String length specified does not match the supported length. Min:0 Max:4,000 supported. Supplied length: 4,006",
        "code": "2050",
        "element": "Description"
      }
    ]
  }
}
```

All specs still pass (although I did get warnings about `Fixnum` being deprecated using Ruby 2.5.0):

```
418 examples, 0 failures
3014 / 3229 LOC (93.34%) covered
```