### PR TITLE
Add Minor Version 4 for Tax > PartnerTaxEnabled in Preferences …

### DIFF
--- a/lib/quickbooks/model/preferences.rb
+++ b/lib/quickbooks/model/preferences.rb
@@ -4,6 +4,7 @@ module Quickbooks
       XML_COLLECTION_NODE = "Preferences"
       XML_NODE            = "Preferences"
       REST_RESOURCE       = 'preferences'
+      MINORVERSION        = 4
 
       xml_name XML_NODE
 
@@ -24,7 +25,7 @@ module Quickbooks
                                                 AllowServiceDate? AllowShipping? DefaultShippingAccount? DefaultTerms DefaultCustomerMessage),
         :vendor_and_purchase  => %w(TrackingByCustomer? BillableExpenseTracking? DefaultTerms? DefaultMarkup? POCustomField),
         :time_tracking        => %w(UseServices? BillCustomers? ShowBillRateToAll WorkWeekStartDate MarkTimeEntiresBillable?),
-        :tax                  => %w(UsingSalesTax?),
+        :tax                  => %w(UsingSalesTax? PartnerTaxEnabled?),
         :currency             => %w(MultiCurrencyEnabled? HomeCurrency),
         :report               => %w(ReportBasis)
       }

--- a/lib/quickbooks/service/preferences.rb
+++ b/lib/quickbooks/service/preferences.rb
@@ -2,6 +2,11 @@ module Quickbooks
   module Service
     class Preferences < BaseService
 
+      def url_for_query(query = nil, start_position = 1, max_results = 20, options = {})
+        url = super(query, start_position, max_results, options)
+        "#{url}&minorversion=#{Quickbooks::Model::Preferences::MINORVERSION}"
+      end
+
       private
       
       def model

--- a/spec/fixtures/preferences.xml
+++ b/spec/fixtures/preferences.xml
@@ -106,6 +106,7 @@ Demo Company</Message>
   </TimeTrackingPrefs>
   <TaxPrefs>
     <UsingSalesTax>false</UsingSalesTax>
+    <PartnerTaxEnabled>false</PartnerTaxEnabled>
   </TaxPrefs>
   <CurrencyPrefs>
     <MultiCurrencyEnabled>false</MultiCurrencyEnabled>

--- a/spec/lib/quickbooks/model/preferences_spec.rb
+++ b/spec/lib/quickbooks/model/preferences_spec.rb
@@ -7,6 +7,7 @@ describe "Quickbooks::Model::Preferences" do
     preferences.currency.home_currency.should == "USD"
 
     preferences.tax.using_sales_tax?.should be_false
+    preferences.tax.partner_tax_enabled?.should be_false
     preferences.time_tracking.bill_customers?.should be_true
 
     preferences.email_messages.invoice_message.subject.should == "Invoice from Demo Company"


### PR DESCRIPTION
To find out if Company is Using Automated sales Tax we need:
[PartnerTaxEnabled](https://developer.intuit.com/hub/blog/2017/12/11/using-quickbooks-online-api-automated-sales-tax) from Preferences. 
Added Minor Version 4 to get the Flag.


How does an app determine if a company is automated tax service enabled?
Query the Preferences.TaxPrefs.PartnerTaxEnabled attribute, available with minor version 4.

If true, automated sales tax is enabled for the company and sales tax is set up.
If false, automated sales tax is enabled for the company but the company doesn’t have sales tax set up.
If not present in response payload, the company is not enabled for automated sales tax.
