### PR TITLE
Relax oauth gem dependency

### DIFF
--- a/quickbooks-ruby.gemspec
+++ b/quickbooks-ruby.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
 
   gem.files = Dir['lib/**/*']
 
-  gem.add_dependency 'oauth', '0.4.7'
+  gem.add_dependency 'oauth', '~> 0.4.5'
   gem.add_dependency 'roxml', '>= 3.3.1', '< 4.1'
   gem.add_dependency 'nokogiri'  # promiscuous mode
   gem.add_dependency 'activemodel' # promiscuous mode


### PR DESCRIPTION
The current version constraint requires every app using this gem to also use `oauth` version 0.4.7. For apps that already use `oauth`, as is the case with Clio, bundler fails to resolve a version of `oauth` that works satisfies all conditions.

In this commit, I’ve relaxed the version constraint to allow anything >= 0.4.5 but < 0.5. To get around this constraint, we’ve been using a [fork](https://github.com/nathan-mots/quickbooks-ruby) but I’d love to get back to using the proper gem.

Is this a change that you'd be open to making?