### PR TITLE
adding LinkedTxn collection into Quickbooks::Model::Bill per v3 API spec

### DIFF
--- a/lib/quickbooks/model/bill.rb
+++ b/lib/quickbooks/model/bill.rb
@@ -19,6 +19,8 @@ module Quickbooks
 
       xml_accessor :private_note, :from => 'PrivateNote'
 
+      xml_accessor :linked_transactions, :from => 'LinkedTxn', :as => [LinkedTransaction]
+
       xml_accessor :vendor_ref, :from => 'VendorRef', :as => BaseReference
       xml_accessor :payer_ref, :from => 'PayerRef', :as => BaseReference
       xml_accessor :sales_term_ref, :from => 'SalesTermRef', :as => BaseReference

--- a/lib/quickbooks/model/linked_transaction.rb
+++ b/lib/quickbooks/model/linked_transaction.rb
@@ -1,9 +1,16 @@
 module Quickbooks
   module Model
     class LinkedTransaction < BaseModel
+      #== Constants
+      DEFAULT_TXN_TYPE = 'BillPaymentCheck'.freeze
+
       xml_accessor :txn_id, :from => 'TxnId'
       xml_accessor :txn_type, :from => 'TxnType'
       xml_accessor :txn_line_id, :from => 'TxnLineId'
+
+      def bill_payment_check_type?
+        txn_type.to_s == DEFAULT_TXN_TYPE
+      end
     end
   end
 end

--- a/spec/fixtures/bill_linked_transactions.xml
+++ b/spec/fixtures/bill_linked_transactions.xml
@@ -1,0 +1,30 @@
+<Bill xmlns="http://schema.intuit.com/finance/v3">
+  <Id>3526</Id>
+  <SyncToken>1</SyncToken>
+  <MetaData>
+    <CreateTime>2019-01-07T10:45:35-08:00</CreateTime>
+    <LastUpdatedTime>2019-01-07T10:47:25-08:00</LastUpdatedTime>
+  </MetaData>
+  <TxnDate>2019-01-07</TxnDate>
+  <CurrencyRef name="United States Dollar">USD</CurrencyRef>
+  <LinkedTxn>
+    <TxnId>3527</TxnId>
+    <TxnType>BillPaymentCheck</TxnType>
+  </LinkedTxn>
+  <Line>
+    <Id>1</Id>
+    <LineNum>1</LineNum>
+    <Amount>500.00</Amount>
+    <DetailType>AccountBasedExpenseLineDetail</DetailType>
+    <AccountBasedExpenseLineDetail>
+      <AccountRef name="Advertising">7</AccountRef>
+      <BillableStatus>NotBillable</BillableStatus>
+      <TaxCodeRef>NON</TaxCodeRef>
+    </AccountBasedExpenseLineDetail>
+  </Line>
+  <VendorRef name="Bob's Burger Joint">56</VendorRef>
+  <APAccountRef name="Accounts Payable (A/P)">33</APAccountRef>
+  <TotalAmt>500.00</TotalAmt>
+  <DueDate>2019-01-07</DueDate>
+  <Balance>0</Balance>
+</Bill>

--- a/spec/lib/quickbooks/model/bill_spec.rb
+++ b/spec/lib/quickbooks/model/bill_spec.rb
@@ -43,6 +43,14 @@ describe "Quickbooks::Model::Bill" do
     line_item1.item_based_expense_item?.should == true
   end
 
+  it "can parse a bill with LinkedTxn from XML" do
+    xml = fixture("bill_linked_transactions.xml")
+    bill = Quickbooks::Model::Bill.from_xml(xml)
+    bill.linked_transactions.size.should == 1
+    linked_txn1 = bill.linked_transactions[0]
+    linked_txn1.bill_payment_check_type?.should == true
+  end
+
   describe "#global_tax_calculation" do
     subject { Quickbooks::Model::Bill.new }
     it_should_behave_like "a model with a valid GlobalTaxCalculation", "TaxInclusive"


### PR DESCRIPTION
## Intent

To un parse `LinkedTxn` attribute into `QuickBooks::Model::Bill` from XML per (API description)[ https://developer.intuit.com/app/developer/qbo/docs/api/accounting/most-commonly-used/bill]

Example of XML payload
```xml
<Bill xmlns="http://schema.intuit.com/finance/v3">
  .....
  <LinkedTxn>
    <TxnId>3527</TxnId>
    <TxnType>BillPaymentCheck</TxnType>
  </LinkedTxn>
   .....
</Bill>
```

## Usage:
```ruby
bill.linked_transactions.each do |trx|
  # some logic
end
```