### PR TITLE
BaseModel includes ActiveModel::AttributeAssignment

### DIFF
--- a/lib/quickbooks/model/base_model.rb
+++ b/lib/quickbooks/model/base_model.rb
@@ -4,6 +4,7 @@ module Quickbooks
       include Definition
       include ActiveModel::AttributeMethods
       include ActiveModel::Validations
+      include ActiveModel::AttributeAssignment
       include Validator
       include ROXML
 

--- a/spec/lib/quickbooks/model/base_model_spec.rb
+++ b/spec/lib/quickbooks/model/base_model_spec.rb
@@ -74,7 +74,7 @@ describe "Quickbooks::Model::BaseModel" do
     it "assigns values into attributes" do
       foo_model.assign_attributes({ baz: "quiz", bar: { foo: 1 }, amount: 30 })
 
-      foo_model.attributes.should eq("baz" => "quiz", "bar" => {"foo" => 1}, "amount" => 30)
+      expect(foo_model.attributes).to eq("baz" => "quiz", "bar" => {"foo" => 1}, "amount" => 30)
     end
   end
 

--- a/spec/lib/quickbooks/model/base_model_spec.rb
+++ b/spec/lib/quickbooks/model/base_model_spec.rb
@@ -70,6 +70,14 @@ describe "Quickbooks::Model::BaseModel" do
     end
   end
 
+  describe "#assign_attributes=" do
+    it "assigns values into attributes" do
+      foo_model.assign_attributes({ baz: "quiz", bar: { foo: 1 }, amount: 30 })
+
+      foo_model.attributes.should eq("baz" => "quiz", "bar" => {"foo" => 1}, "amount" => 30)
+    end
+  end
+
   describe "#[]" do
     it "delegates to the underlying attributes" do
       expect(bar_model[:foo]).to eq(42)


### PR DESCRIPTION
## Changes

Add following functions by including ActiveModel::AttributeAssignment:

* Quickbooks::Model::BaseModel#assign_attributes (Added test)
* Quickbooks::Model::BaseModel#attributes= (No test)

## Notes

* Added a `assign_attributes` test case, it's duplicated with ActiveModel's test but I think it's ok to duplicate it so we can make sure it works on this gem.
* While working on this gem, I found the rspec dependency is still `2.14.1` which is relatively old compare to current version `3.8.0`, this bothered me because I was trying to use `aggregate_failures` function to test getters from `#assign_attributes` separately so there won't be dependency with `#attributes` test, are you considering update `rspec` to current version in the future? Happy to help with it as well.

## Reference

* https://github.com/ruckus/quickbooks-ruby/issues/451
* https://api.rubyonrails.org/classes/ActiveModel/AttributeAssignment.html
