### PR TITLE
log response headers.   Most interesting is the Intuit TID, which Intuit Support may ask for.

### DIFF
--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -258,6 +258,8 @@ module Quickbooks
       end
 
       def check_response(response, options = {})
+        log "------ RESPONSE_HEADERS -----"
+        response.each_header {|h| log "#{h}: #{response[h]}"}        
         log "------ QUICKBOOKS-RUBY RESPONSE ------"
         log "RESPONSE CODE = #{response.code}"
         log_response_body(response)


### PR DESCRIPTION
We may just want the Intuit TID.  If so, instead of "each_header", we can just log

  response['intuit_tid']