### PR TITLE
Allow to use any patch version of Oauth2 v1.4 gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,11 @@ rvm:
   - 2.0.0
   - 2.1.0
   - 2.2.0
+  - 2.3.0
+  - 2.4.0
+  - 2.5.0
 # Bundler 1.13 added support for `ruby RUBY_VERSION` in the Gemfile
-before_install: gem install bundler -v '>= 1.13.0'
+before_install: gem install bundler -v '1.17.3'
 
 sudo: false
 notifications:

--- a/quickbooks-ruby.gemspec
+++ b/quickbooks-ruby.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.files = Dir['lib/**/*']
 
   gem.add_dependency 'oauth', '0.4.7'
-  gem.add_dependency 'oauth2', '1.4.0'
+  gem.add_dependency 'oauth2', '1.4.1'
   gem.add_dependency 'roxml', '4.0.0'
   gem.add_dependency 'nokogiri'  # promiscuous mode
   gem.add_dependency 'activemodel' # promiscuous mode

--- a/quickbooks-ruby.gemspec
+++ b/quickbooks-ruby.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.files = Dir['lib/**/*']
 
   gem.add_dependency 'oauth', '0.4.7'
-  gem.add_dependency 'oauth2', '1.4.1'
+  gem.add_dependency 'oauth2', '~>1.4'
   gem.add_dependency 'roxml', '4.0.0'
   gem.add_dependency 'nokogiri'  # promiscuous mode
   gem.add_dependency 'activemodel' # promiscuous mode


### PR DESCRIPTION
Oauth2 library aims to adhere to Semantic Versioning 2.0.0, it means that we can use any patch version. Is it possible to confirm this pull? I want to use oauth2 1.4.1 because it is impossible to use 1.4.0 in my application. I already checked 1.4.1 in my dev env.