### PR TITLE
exposing time attribute from response received via CDC endpoint

### DIFF
--- a/lib/quickbooks/model/change_data_capture.rb
+++ b/lib/quickbooks/model/change_data_capture.rb
@@ -19,6 +19,13 @@ module Quickbooks
          data
       end
 
+      # time when refresh was requests from cdc/ endpoiint
+      # more information @here - https://developer.intuit.com/app/developer/qbo/docs/develop/explore-the-quickbooks-online-api/change-data-capture#using-change-data-capture
+      #
+      def time
+        xml.root.attribute('time')&.value
+      end
+
       private
 
       def all_of_type(entity)

--- a/lib/quickbooks/model/change_data_capture.rb
+++ b/lib/quickbooks/model/change_data_capture.rb
@@ -23,7 +23,8 @@ module Quickbooks
       # more information @here - https://developer.intuit.com/app/developer/qbo/docs/develop/explore-the-quickbooks-online-api/change-data-capture#using-change-data-capture
       #
       def time
-        xml.root.attribute('time')&.value
+        attribute = xml.root.attribute('time')
+        attribute.value if attribute
       end
 
       private

--- a/spec/lib/quickbooks/model/change_data_capture_spec.rb
+++ b/spec/lib/quickbooks/model/change_data_capture_spec.rb
@@ -14,6 +14,7 @@ describe "Quickbooks::Model::ChangeDataCapture" do
   it "should produce full models for returned entities" do
     xml = Nokogiri::XML(fixture("change_data_capture_response.xml"))
     response = Quickbooks::Model::ChangeDataCapture.new(xml: xml)
+    response.time == "2016-04-13T07:52:34.949-07:00"
     invoice = response.all_types["Invoice"].first
 
     invoice.meta_data.should_not be_nil


### PR DESCRIPTION
# Why
This value can be useful when running various sync and want to rely on previous sync time before executing a new one.

Pretty small change but its cleaner than forcing responsibility to lookup it in `xml.root.attribute` 