### PR TITLE
Closes #467 - Allow disconnect of OAuth2 tokens

### DIFF
--- a/lib/quickbooks/service/access_token.rb
+++ b/lib/quickbooks/service/access_token.rb
@@ -24,14 +24,14 @@ module Quickbooks
       def disconnect
         result = nil
 
-        disconnect_url = nil
-
         if oauth_v1?
-          disconnect_url = DISCONNECT_URL_OAUTH1
+          response = do_http_get(DISCONNECT_URL_OAUTH1)
         elsif oauth_v2?
-          disconnect_url = DISCONNECT_URL_OAUTH2
+          conn = Faraday.new
+          conn.basic_auth oauth.client.id, oauth.client.secret
+          raw_response = conn.post(DISCONNECT_URL_OAUTH2, { token: oauth.refresh_token || oauth.token })
+          response = Quickbooks::Service::Responses::OAuth2HttpResponse.new(raw_response)
         end
-        response = do_http_get(disconnect_url)
 
         if response
           code = response.code.to_i

--- a/spec/lib/quickbooks/service/access_token_spec.rb
+++ b/spec/lib/quickbooks/service/access_token_spec.rb
@@ -46,7 +46,7 @@ describe Quickbooks::Service::AccessToken do
 
   it "can successfully disconnect [oauth2]" do
     xml = fixture("disconnect_200.xml")
-    stub_http_request(:get, Quickbooks::Service::AccessToken::DISCONNECT_URL_OAUTH2, ["200", "OK"], xml, true)
+    stub_http_request(:post, Quickbooks::Service::AccessToken::DISCONNECT_URL_OAUTH2, ["200", "OK"], xml, true)
 
     response = @service.disconnect
     response.error?.should == false
@@ -54,8 +54,7 @@ describe Quickbooks::Service::AccessToken do
 
   it "can fail to disconnect if the auth token is invalid [oauth2]" do
     xml = fixture("disconnect_270.xml")
-    stub_http_request(:get, Quickbooks::Service::AccessToken::DISCONNECT_URL_OAUTH2, ["200", "OK"], xml, true)
-
+    stub_http_request(:post, Quickbooks::Service::AccessToken::DISCONNECT_URL_OAUTH2, ["200", "OK"], xml, true)
     response = @service.disconnect
     response.error?.should == true
     response.error_code.should    == "270"


### PR DESCRIPTION
- OAuth2 disconnect requires POST instead of GET
- We can't use `do_http_post` becuase it uses `OAuth2::AccessToken#post` which overwrides the `Authorization` header, so use Faraday to send the `POST` request to disconnect