### PR TITLE
#467 - Fix error when OAuth2 disconnect succeeds

### DIFF
--- a/lib/quickbooks/service/access_token.rb
+++ b/lib/quickbooks/service/access_token.rb
@@ -22,25 +22,24 @@ module Quickbooks
 
       # https://developer.intuit.com/docs/0025_quickbooksapi/0053_auth_auth/oauth_management_api#Disconnect
       def disconnect
-        result = nil
-
         if oauth_v1?
           response = do_http_get(DISCONNECT_URL_OAUTH1)
+          if response && response.code.to_i == 200
+            Quickbooks::Model::AccessTokenResponse.from_xml(response.plain_body)
+          end
         elsif oauth_v2?
           conn = Faraday.new
           conn.basic_auth oauth.client.id, oauth.client.secret
-          raw_response = conn.post(DISCONNECT_URL_OAUTH2, { token: oauth.refresh_token || oauth.token })
-          response = Quickbooks::Service::Responses::OAuth2HttpResponse.new(raw_response)
-        end
+          response = conn.post(DISCONNECT_URL_OAUTH2, token: oauth.refresh_token || oauth.token)
 
-        if response
-          code = response.code.to_i
-          if code == 200
-            result = Quickbooks::Model::AccessTokenResponse.from_xml(response.plain_body)
+          if response.success?
+            Quickbooks::Model::AccessTokenResponse.new(error_code: "0")
+          else
+            Quickbooks::Model::AccessTokenResponse.new(
+              error_code: response.status.to_s, error_message: response.reason_phrase
+            )
           end
         end
-
-        result
       end
 
     end

--- a/spec/lib/quickbooks/service/access_token_spec.rb
+++ b/spec/lib/quickbooks/service/access_token_spec.rb
@@ -45,20 +45,19 @@ describe Quickbooks::Service::AccessToken do
   end
 
   it "can successfully disconnect [oauth2]" do
-    xml = fixture("disconnect_200.xml")
-    stub_http_request(:post, Quickbooks::Service::AccessToken::DISCONNECT_URL_OAUTH2, ["200", "OK"], xml, true)
+    stub_http_request(:post, Quickbooks::Service::AccessToken::DISCONNECT_URL_OAUTH2, ["200", "OK"], "", true)
 
     response = @service.disconnect
     response.error?.should == false
   end
 
   it "can fail to disconnect if the auth token is invalid [oauth2]" do
-    xml = fixture("disconnect_270.xml")
-    stub_http_request(:post, Quickbooks::Service::AccessToken::DISCONNECT_URL_OAUTH2, ["200", "OK"], xml, true)
+    stub_http_request(:post, Quickbooks::Service::AccessToken::DISCONNECT_URL_OAUTH2, ["400", "Bad Request"], "", true)
+
     response = @service.disconnect
     response.error?.should == true
-    response.error_code.should    == "270"
-    response.error_message.should == "OAuth Token rejected"
+    response.error_code.should    == "400"
+    response.error_message.should == "Bad Request"
   end
 
 end


### PR DESCRIPTION
Even when setting the accepts header to xml, the OAuth2 disconnect endpoint always returns an empty body.

So, I updated the stubbed requests in the specs to duplicate the bug, and changed the approach to construct a `Quickbooks::Model::AccessTokenResponse` with the appropriate fields for success/fail.

I don't love this solution, but short of modifying `Quickbooks::Model::AccessTokenResponse` to function completely differently, this seems ok - the external interface remains the same.

/cc @Zajn 