### PR TITLE
Error code 502 throws ServiceUnavailable

### DIFF
--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -342,7 +342,7 @@ module Quickbooks
         when 429
           message = parse_intuit_error[:message]
           raise Quickbooks::TooManyRequests, message
-        when 503, 504
+        when 502, 503, 504
           raise Quickbooks::ServiceUnavailable
         else
           raise "HTTP Error Code: #{status}, Msg: #{response.plain_body}"

--- a/spec/lib/quickbooks/service/base_service_spec.rb
+++ b/spec/lib/quickbooks/service/base_service_spec.rb
@@ -139,8 +139,11 @@ describe Quickbooks::Service::BaseService do
       expect { @service.send(:check_response, response) }.to raise_error(Quickbooks::TooManyRequests, message)
     end
 
-    it "should raise ServiceUnavailable on HTTP 503 and 504" do
+    it "should raise ServiceUnavailable on HTTP 502, 503 and 504" do
       xml = fixture('generic_error.xml')
+
+      response = Struct.new(:code, :plain_body).new(502, xml)
+      expect { @service.send(:check_response, response) }.to raise_error(Quickbooks::ServiceUnavailable)
 
       response = Struct.new(:code, :plain_body).new(503, xml)
       expect { @service.send(:check_response, response) }.to raise_error(Quickbooks::ServiceUnavailable)


### PR DESCRIPTION
Error code 502 is being thrown as a StandardError in the new release.

It was a ServiceUnavailable Error prior to the new release as the change was made here >> https://github.com/ruckus/quickbooks-ruby/pull/431

Bringing it back as it seems like a bug.