### PR TITLE
Use pessimistic version constraint on oauth dependency

### DIFF
--- a/quickbooks-ruby.gemspec
+++ b/quickbooks-ruby.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
 
   gem.files = Dir['lib/**/*']
 
-  gem.add_dependency 'oauth', '0.4.7'
+  gem.add_dependency 'oauth', '~>0.4.7'
   gem.add_dependency 'oauth2', '~>1.4'
   gem.add_dependency 'roxml', '4.0.0'
   gem.add_dependency 'nokogiri'  # promiscuous mode


### PR DESCRIPTION
### Purpose

With OAuth 2 support recently merged, a change was made to the oauth dependency that only resolves to a specific version. This change is to bring back support for an approximate oauth version to play better with other dependencies that might be in the same project.

[This change](https://github.com/ruckus/quickbooks-ruby/commit/6e5eac86368d3becf3b35b3519e079302a4d5655#diff-da82320b49f9ab083076f15d5adb8505L17), specifically.