### PR TITLE
Add minorversion to account service and update query url

### DIFF
--- a/lib/quickbooks/model/account.rb
+++ b/lib/quickbooks/model/account.rb
@@ -4,6 +4,7 @@ module Quickbooks
       XML_COLLECTION_NODE = "Account"
       XML_NODE = "Account"
       REST_RESOURCE = 'account'
+      MINORVERSION = 13
 
       ASSET = 'Asset'
       EQUITY = 'Equity'

--- a/lib/quickbooks/service/account.rb
+++ b/lib/quickbooks/service/account.rb
@@ -7,6 +7,11 @@ module Quickbooks
         update(account, :sparse => true)
       end
 
+      def url_for_query(query = nil, start_position = 1, max_results = 20, options = {})
+        url = super(query, start_position, max_results, options)
+        "#{url}&minorversion=#{Quickbooks::Model::Account::MINORVERSION}"
+      end
+
       private
 
       def model


### PR DESCRIPTION
This PR adds a minorversion of 13 to the Account model and updates `Quickbooks::Service::Account` `url_for_query` method to include that minorversion.

See https://github.com/ruckus/quickbooks-ruby/issues/487 for an explanation of why this is desirable.