### PR TITLE
Better errors

### DIFF
--- a/lib/quickbooks-ruby.rb
+++ b/lib/quickbooks-ruby.rb
@@ -231,7 +231,16 @@ module Quickbooks
 
   class Error < StandardError; end
   class InvalidModelException < Error; end
-  class AuthorizationFailure < Error; end
+  class AuthorizationFailure < Error
+    attr_accessor :code, :detail, :type
+
+    def initialize(error_hash = {})
+      @code = error_hash[:code]
+      @detail = error_hash[:detail]
+      @type = error_hash[:type]
+      super(error_hash[:message])
+    end
+  end
   class Forbidden < Error; end
   class NotFound < Error; end
   class RequestTooLarge < Error; end

--- a/lib/quickbooks-ruby.rb
+++ b/lib/quickbooks-ruby.rb
@@ -250,7 +250,7 @@ module Quickbooks
   class MissingRealmError < Error; end
 
   class IntuitRequestException < Error
-    attr_accessor :message, :code, :detail, :type, :request_xml, :request_json
+    attr_accessor :message, :code, :detail, :type, :intuit_tid, :request_xml, :request_json
 
     def initialize(msg)
       self.message = msg

--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -264,6 +264,12 @@ module Quickbooks
         end
 
         response = Quickbooks::Service::Responses::OAuthHttpResponse.wrap(raw_response)
+        log "------ QUICKBOOKS-RUBY RESPONSE ------"
+        log "RESPONSE CODE = #{response.code}"
+        log_response_body(response)
+        if response.respond_to?(:headers)
+          log "RESPONSE HEADERS = #{response.headers}"
+        end
         check_response(response, request: body)
       end
 
@@ -308,12 +314,12 @@ module Quickbooks
       end
 
       def check_response(response, options = {})
-        log "------ QUICKBOOKS-RUBY RESPONSE ------"
-        log "RESPONSE CODE = #{response.code}"
-        if response.respond_to?(:headers)
-          log "RESPONSE HEADERS = #{response.headers}"
+        if is_json?
+          parse_json(response.plain_body)
+        elsif !is_pdf?
+          parse_xml(response.plain_body)
         end
-        log_response_body(response)
+
         status = response.code.to_i
         case status
         when 200
@@ -353,12 +359,10 @@ module Quickbooks
         log "RESPONSE BODY:"
         if is_json?
           log ">>>>#{response.plain_body.inspect}"
-          parse_json(response.plain_body)
         elsif is_pdf?
           log("BODY is a PDF : not dumping")
         else
           log(log_xml(response.plain_body))
-          parse_xml(response.plain_body)
         end
       end
 

--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -326,7 +326,7 @@ module Quickbooks
         when 302
           raise "Unhandled HTTP Redirect"
         when 401
-          raise Quickbooks::AuthorizationFailure
+          raise Quickbooks::AuthorizationFailure, parse_intuit_error
         when 403
           message = parse_intuit_error[:message]
           if message.include?('ThrottleExceeded')
@@ -426,7 +426,7 @@ module Quickbooks
               error[:code] = code_attr.value
             end
             element_attr = error_element.attributes['element']
-            if code_attr
+            if element_attr
               error[:element] = code_attr.value
             end
             error[:message] = error_element.xpath("//xmlns:Message").text


### PR DESCRIPTION
I've been playing around with this to try to get some better errors to help me with some debugging. 

I'd initially wanted the error message carried over to AuthorizationFailures, in there I noticed that we aren't setting the `element` correctly it was always getting the `code`'s value. 

I tried to separate out the logging and response parsing:
- `do_http` now does the request and response logging... we might not want all that in there but at least it's together now.
- `check_response` now calls the `parse_*` methods. It felt odd to me those were a side effect of the `log_response_body` method.
- There's a fair bit of work to carry the `intuit_tid` header out to the `IntuitRequestException`. I'd been asked for that value by Intuit's tech support to diagnose a 500 and, annoyingly had to enable full logging to discover they weren't including any headers in their error response. I'm not sure how useful that would be for anyone else so happy to revert that part if you'd like.