### PR TITLE
Update SalesFormsPref fields on Preferences model

### DIFF
--- a/lib/quickbooks/model/preferences.rb
+++ b/lib/quickbooks/model/preferences.rb
@@ -4,7 +4,7 @@ module Quickbooks
       XML_COLLECTION_NODE = "Preferences"
       XML_NODE            = "Preferences"
       REST_RESOURCE       = 'preferences'
-      MINORVERSION = 21
+      MINORVERSION = 32
 
       xml_name XML_NODE
 
@@ -28,9 +28,28 @@ module Quickbooks
       }
 
       xml_reader :sales_forms, :from => "SalesFormsPrefs", :as => create_preference_class(*%w(
-        CustomTxnNumbers? AllowDeposit? AllowDiscount? DefaultDiscountAccount? AllowEstimates? EstimateMessage?
-        ETransactionEnabledStatus? ETransactionAttachPDF? ETransactionPaymentEnabled? IPNSupportEnabled?
-        AllowServiceDate? AllowShipping? DefaultShippingAccount? DefaultTerms DefaultCustomerMessage
+        AllowDeposit?
+        AllowDiscount?
+        AllowEstimates?
+        AllowServiceDate?
+        AllowShipping?
+        AutoApplyCredit?
+        CustomField?
+        CustomTxnNumbers?
+        DefaultCustomerMessage
+        DefaultDiscountAccount?
+        DefaultShippingAccount?
+        DefaultTerms
+        EmailCopyToCompany?
+        EstimateMessage
+        ETransactionAttachPDF?
+        ETransactionEnabledStatus
+        ETransactionPaymentEnabled?
+        IPNSupportEnabled?
+        SalesEmailBcc
+        SalesEmailCc
+        UsingPriceLevels?
+        UsingProgressInvoicing?
       )) {
         xml_reader :custom_fields, :as => [CustomField], :from => 'CustomField', in: 'CustomField'
       }

--- a/spec/fixtures/preferences.xml
+++ b/spec/fixtures/preferences.xml
@@ -2,10 +2,17 @@
   <Id>1</Id>
   <SyncToken>0</SyncToken>
   <MetaData>
-    <CreateTime>2014-04-22T01:31:59-07:00</CreateTime>
-    <LastUpdatedTime>2014-05-01T17:44:56-07:00</LastUpdatedTime>
+    <CreateTime>2019-12-03T01:03:32-08:00</CreateTime>
+    <LastUpdatedTime>2019-12-03T16:02:42-08:00</LastUpdatedTime>
   </MetaData>
   <AccountingInfoPrefs>
+    <UseAccountNumbers>false</UseAccountNumbers>
+    <TrackDepartments>false</TrackDepartments>
+    <ClassTrackingPerTxn>false</ClassTrackingPerTxn>
+    <ClassTrackingPerTxnLine>false</ClassTrackingPerTxnLine>
+    <FirstMonthOfFiscalYear>January</FirstMonthOfFiscalYear>
+    <TaxYearMonth>January</TaxYearMonth>
+    <TaxForm>6</TaxForm>
     <CustomerTerminology>Customers</CustomerTerminology>
   </AccountingInfoPrefs>
   <ProductAndServicesPrefs>
@@ -40,6 +47,7 @@
       </CustomField>
     </CustomField>
     <CustomTxnNumbers>false</CustomTxnNumbers>
+    <EmailCopyToCompany>false</EmailCopyToCompany>
     <AllowDeposit>false</AllowDeposit>
     <AllowDiscount>false</AllowDiscount>
     <AllowEstimates>true</AllowEstimates>
@@ -49,7 +57,10 @@
     <IPNSupportEnabled>false</IPNSupportEnabled>
     <AllowServiceDate>false</AllowServiceDate>
     <AllowShipping>false</AllowShipping>
-    <DefaultTerms>3</DefaultTerms>
+    <AutoApplyCredit>true</AutoApplyCredit>
+    <AutoApplyPayments>true</AutoApplyPayments>
+    <UsingPriceLevels>false</UsingPriceLevels>
+    <DefaultCustomerMessage>Thank you for your business and have a great day!</DefaultCustomerMessage>
   </SalesFormsPrefs>
   <EmailMessagesPrefs>
     <InvoiceMessage>
@@ -109,6 +120,7 @@ Demo Company</Message>
     <UseServices>false</UseServices>
     <BillCustomers>true</BillCustomers>
     <ShowBillRateToAll>false</ShowBillRateToAll>
+    <WorkWeekStartDate>Monday</WorkWeekStartDate>
     <MarkTimeEntriesBillable>true</MarkTimeEntriesBillable>
   </TimeTrackingPrefs>
   <TaxPrefs>
@@ -126,14 +138,91 @@ Demo Company</Message>
   <OtherPrefs>
     <NameValue>
       <Name>SalesFormsPrefs.DefaultCustomerMessage</Name>
+      <Value>Thank you for your business and have a great day!</Value>
     </NameValue>
     <NameValue>
       <Name>SalesFormsPrefs.DefaultItem</Name>
       <Value>1</Value>
     </NameValue>
     <NameValue>
+      <Name>DTXCopyMemo</Name>
+      <Value>true</Value>
+    </NameValue>
+    <NameValue>
+      <Name>UncategorizedAssetAccountId</Name>
+      <Value>91</Value>
+    </NameValue>
+    <NameValue>
+      <Name>UncategorizedIncomeAccountId</Name>
+      <Value>92</Value>
+    </NameValue>
+    <NameValue>
+      <Name>UncategorizedExpenseAccountId</Name>
+      <Value>93</Value>
+    </NameValue>
+    <NameValue>
       <Name>SFCEnabled</Name>
       <Value>true</Value>
+    </NameValue>
+    <NameValue>
+      <Name>DataPartner</Name>
+      <Value>false</Value>
+    </NameValue>
+    <NameValue>
+      <Name>Vendor1099Enabled</Name>
+      <Value>true</Value>
+    </NameValue>
+    <NameValue>
+      <Name>TimeTrackingFeatureEnabled</Name>
+      <Value>true</Value>
+    </NameValue>
+    <NameValue>
+      <Name>FDPEnabled</Name>
+      <Value>false</Value>
+    </NameValue>
+    <NameValue>
+      <Name>isDTXOnStage</Name>
+      <Value>false</Value>
+    </NameValue>
+    <NameValue>
+      <Name>ProjectsEnabled</Name>
+      <Value>false</Value>
+    </NameValue>
+    <NameValue>
+      <Name>DateFormat</Name>
+      <Value>Month Date Year separated by a slash</Value>
+    </NameValue>
+    <NameValue>
+      <Name>DateFormatMnemonic</Name>
+      <Value>MMDDYYYY_SEP_SLASH</Value>
+    </NameValue>
+    <NameValue>
+      <Name>NumberFormat</Name>
+      <Value>US Number Format</Value>
+    </NameValue>
+    <NameValue>
+      <Name>NumberFormatMnemonic</Name>
+      <Value>US_NB</Value>
+    </NameValue>
+    <NameValue>
+      <Name>WarnDuplicateCheckNumber</Name>
+      <Value>true</Value>
+    </NameValue>
+    <NameValue>
+      <Name>WarnDuplicateBillNumber</Name>
+      <Value>false</Value>
+    </NameValue>
+    <NameValue>
+      <Name>WarnDuplicateJournalNumber</Name>
+      <Value>false</Value>
+    </NameValue>
+    <NameValue>
+      <Name>SignoutInactiveMinutes</Name>
+      <Value>60</Value>
+    </NameValue>
+    <NameValue>
+      <Name>AccountingInfoPrefs.ShowAccountNumbers</Name>
+      <Value>false</Value>
     </NameValue>
   </OtherPrefs>
 </Preferences>

--- a/spec/fixtures/preferences_query.xml
+++ b/spec/fixtures/preferences_query.xml
@@ -1,21 +1,27 @@
-<?xml version="1.0"?>
-<IntuitResponse xmlns="http://schema.intuit.com/finance/v3" time="2013-07-11T08:30:10.953-07:00">
+<IntuitResponse xmlns="http://schema.intuit.com/finance/v3" time="2019-12-05T09:50:38.974-08:00">
   <QueryResponse maxResults="1">
     <Preferences domain="QBO" sparse="false">
       <Id>1</Id>
-      <SyncToken>0</SyncToken>
+      <SyncToken>3</SyncToken>
       <MetaData>
-        <CreateTime>2014-04-22T01:31:59-07:00</CreateTime>
-        <LastUpdatedTime>2014-05-01T17:44:56-07:00</LastUpdatedTime>
+        <CreateTime>2019-12-03T01:03:32-08:00</CreateTime>
+        <LastUpdatedTime>2019-12-03T16:02:42-08:00</LastUpdatedTime>
       </MetaData>
       <AccountingInfoPrefs>
+        <UseAccountNumbers>false</UseAccountNumbers>
+        <TrackDepartments>false</TrackDepartments>
+        <ClassTrackingPerTxn>false</ClassTrackingPerTxn>
+        <ClassTrackingPerTxnLine>false</ClassTrackingPerTxnLine>
+        <FirstMonthOfFiscalYear>January</FirstMonthOfFiscalYear>
+        <TaxYearMonth>January</TaxYearMonth>
+        <TaxForm>6</TaxForm>
         <CustomerTerminology>Customers</CustomerTerminology>
       </AccountingInfoPrefs>
       <ProductAndServicesPrefs>
         <ForSales>true</ForSales>
-        <ForPurchase>false</ForPurchase>
+        <ForPurchase>true</ForPurchase>
         <QuantityWithPriceAndRate>true</QuantityWithPriceAndRate>
-        <QuantityOnHand>false</QuantityOnHand>
+        <QuantityOnHand>true</QuantityOnHand>
       </ProductAndServicesPrefs>
       <SalesFormsPrefs>
         <CustomField xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="BooleanTypeCustomFieldDefinition">
@@ -25,97 +31,109 @@
             <BooleanValue>false</BooleanValue>
           </CustomField>
           <CustomField>
+            <Name>SalesFormsPrefs.UseSalesCustom1</Name>
+            <Type>BooleanType</Type>
+            <BooleanValue>true</BooleanValue>
+          </CustomField>
+          <CustomField>
             <Name>SalesFormsPrefs.UseSalesCustom2</Name>
             <Type>BooleanType</Type>
             <BooleanValue>false</BooleanValue>
           </CustomField>
-          <CustomField>
-            <Name>SalesFormsPrefs.UseSalesCustom1</Name>
-            <Type>BooleanType</Type>
-            <BooleanValue>false</BooleanValue>
-          </CustomField>
-        </CustomField>
-        <CustomField xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="StringTypeCustomFieldDefinition">
-          <CustomField>
-            <Name>SalesFormsPrefs.SalesCustomName1</Name>
-            <Type>StringType</Type>
-            <StringValue>Reference</StringValue>
-          </CustomField>
         </CustomField>
         <CustomTxnNumbers>false</CustomTxnNumbers>
+        <EmailCopyToCompany>false</EmailCopyToCompany>
         <AllowDeposit>false</AllowDeposit>
         <AllowDiscount>false</AllowDiscount>
         <AllowEstimates>true</AllowEstimates>
-        <ETransactionEnabledStatus>Enabled</ETransactionEnabledStatus>
+        <ETransactionEnabledStatus>NotApplicable</ETransactionEnabledStatus>
         <ETransactionAttachPDF>false</ETransactionAttachPDF>
         <ETransactionPaymentEnabled>false</ETransactionPaymentEnabled>
         <IPNSupportEnabled>false</IPNSupportEnabled>
         <AllowServiceDate>false</AllowServiceDate>
         <AllowShipping>false</AllowShipping>
-        <DefaultTerms>3</DefaultTerms>
+        <AutoApplyCredit>true</AutoApplyCredit>
+        <AutoApplyPayments>true</AutoApplyPayments>
+        <UsingPriceLevels>false</UsingPriceLevels>
+        <DefaultCustomerMessage>Thank you for your business and have a great day!</DefaultCustomerMessage>
       </SalesFormsPrefs>
       <EmailMessagesPrefs>
         <InvoiceMessage>
-          <Subject>Invoice from Demo Company</Subject>
-          <Message>Here's your invoice! We appreciate your prompt payment.
+          <Subject>Invoice from Craig's Design and Landscaping Services</Subject>
+          <Message>Your invoice is attached.  Please remit payment at your earliest convenience.
+Thank you for your business - we appreciate it very much.
 
-    Thanks for your business!
-    Demo Company</Message>
+Sincerely,
+Craig's Design and Landscaping Services</Message>
         </InvoiceMessage>
         <EstimateMessage>
-          <Subject>Estimate from Demo Company</Subject>
+          <Subject>Estimate from Craig's Design and Landscaping Services</Subject>
           <Message>Please review the estimate below.  Feel free to contact us if you have any questions.
-    We look forward to working with you.
+We look forward to working with you.
 
-    Thanks for your business!
-    Demo Company</Message>
+Sincerely,
+Craig's Design and Landscaping Services</Message>
         </EstimateMessage>
         <SalesReceiptMessage>
-          <Subject>Sales Receipt from Demo Company</Subject>
+          <Subject>Sales Receipt from Craig's Design and Landscaping Services</Subject>
           <Message>Your sales receipt is attached.
-    Thank you for your business - we appreciate it very much.
+Thank you for your business - we appreciate it very much.
 
-    Thanks for your business!
-    Demo Company</Message>
+Sincerely,
+Craig's Design and Landscaping Services</Message>
         </SalesReceiptMessage>
         <StatementMessage>
-          <Subject>Statement from Demo Company</Subject>
+          <Subject>Statement from Craig's Design and Landscaping Services</Subject>
           <Message>Your statement is attached.  Please remit payment at your earliest convenience.
-    Thank you for your business - we appreciate it very much.
+Thank you for your business - we appreciate it very much.
 
-    Thanks for your business!
-    Demo Company</Message>
+Sincerely,
+Craig's Design and Landscaping Services</Message>
         </StatementMessage>
       </EmailMessagesPrefs>
       <VendorAndPurchasesPrefs>
-        <TrackingByCustomer>false</TrackingByCustomer>
+        <TrackingByCustomer>true</TrackingByCustomer>
         <BillableExpenseTracking>false</BillableExpenseTracking>
         <POCustomField xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="BooleanTypeCustomFieldDefinition">
+          <CustomField>
+            <Name>PurchasePrefs.UsePurchaseCustom1</Name>
+            <Type>BooleanType</Type>
+            <BooleanValue>true</BooleanValue>
+          </CustomField>
+          <CustomField>
+            <Name>PurchasePrefs.UsePurchaseCustom2</Name>
+            <Type>BooleanType</Type>
+            <BooleanValue>true</BooleanValue>
+          </CustomField>
           <CustomField>
             <Name>PurchasePrefs.UsePurchaseCustom3</Name>
             <Type>BooleanType</Type>
             <BooleanValue>false</BooleanValue>
           </CustomField>
+        </POCustomField>
+        <POCustomField xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="StringTypeCustomFieldDefinition">
           <CustomField>
-            <Name>PurchasePrefs.UsePurchaseCustom2</Name>
-            <Type>BooleanType</Type>
-            <BooleanValue>false</BooleanValue>
+            <Name>PurchasePrefs.PurchaseCustomName1</Name>
+            <Type>StringType</Type>
+            <StringValue>Crew #</StringValue>
           </CustomField>
           <CustomField>
-            <Name>PurchasePrefs.UsePurchaseCustom1</Name>
-            <Type>BooleanType</Type>
-            <BooleanValue>false</BooleanValue>
+            <Name>PurchasePrefs.PurchaseCustomName2</Name>
+            <Type>StringType</Type>
+            <StringValue>Sales Rep</StringValue>
           </CustomField>
         </POCustomField>
       </VendorAndPurchasesPrefs>
       <TimeTrackingPrefs>
-        <UseServices>false</UseServices>
+        <UseServices>true</UseServices>
         <BillCustomers>true</BillCustomers>
         <ShowBillRateToAll>false</ShowBillRateToAll>
+        <WorkWeekStartDate>Monday</WorkWeekStartDate>
         <MarkTimeEntriesBillable>true</MarkTimeEntriesBillable>
       </TimeTrackingPrefs>
       <TaxPrefs>
         <UsingSalesTax>false</UsingSalesTax>
+        <PartnerTaxEnabled>false</PartnerTaxEnabled>
       </TaxPrefs>
       <CurrencyPrefs>
         <MultiCurrencyEnabled>false</MultiCurrencyEnabled>
@@ -128,14 +146,91 @@
       <OtherPrefs>
         <NameValue>
           <Name>SalesFormsPrefs.DefaultCustomerMessage</Name>
+          <Value>Thank you for your business and have a great day!</Value>
         </NameValue>
         <NameValue>
           <Name>SalesFormsPrefs.DefaultItem</Name>
-          <Value>1</Value>
+          <Value>19</Value>
+        </NameValue>
+        <NameValue>
+          <Name>DTXCopyMemo</Name>
+          <Value>true</Value>
+        </NameValue>
+        <NameValue>
+          <Name>UncategorizedAssetAccountId</Name>
+          <Value>91</Value>
+        </NameValue>
+        <NameValue>
+          <Name>UncategorizedIncomeAccountId</Name>
+          <Value>92</Value>
+        </NameValue>
+        <NameValue>
+          <Name>UncategorizedExpenseAccountId</Name>
+          <Value>93</Value>
         </NameValue>
         <NameValue>
           <Name>SFCEnabled</Name>
           <Value>true</Value>
+        </NameValue>
+        <NameValue>
+          <Name>DataPartner</Name>
+          <Value>false</Value>
+        </NameValue>
+        <NameValue>
+          <Name>Vendor1099Enabled</Name>
+          <Value>true</Value>
+        </NameValue>
+        <NameValue>
+          <Name>TimeTrackingFeatureEnabled</Name>
+          <Value>true</Value>
+        </NameValue>
+        <NameValue>
+          <Name>FDPEnabled</Name>
+          <Value>false</Value>
+        </NameValue>
+        <NameValue>
+          <Name>isDTXOnStage</Name>
+          <Value>false</Value>
+        </NameValue>
+        <NameValue>
+          <Name>ProjectsEnabled</Name>
+          <Value>false</Value>
+        </NameValue>
+        <NameValue>
+          <Name>DateFormat</Name>
+          <Value>Month Date Year separated by a slash</Value>
+        </NameValue>
+        <NameValue>
+          <Name>DateFormatMnemonic</Name>
+          <Value>MMDDYYYY_SEP_SLASH</Value>
+        </NameValue>
+        <NameValue>
+          <Name>NumberFormat</Name>
+          <Value>US Number Format</Value>
+        </NameValue>
+        <NameValue>
+          <Name>NumberFormatMnemonic</Name>
+          <Value>US_NB</Value>
+        </NameValue>
+        <NameValue>
+          <Name>WarnDuplicateCheckNumber</Name>
+          <Value>true</Value>
+        </NameValue>
+        <NameValue>
+          <Name>WarnDuplicateBillNumber</Name>
+          <Value>false</Value>
+        </NameValue>
+        <NameValue>
+          <Name>WarnDuplicateJournalNumber</Name>
+          <Value>false</Value>
+        </NameValue>
+        <NameValue>
+          <Name>SignoutInactiveMinutes</Name>
+          <Value>60</Value>
+        </NameValue>
+        <NameValue>
+          <Name>AccountingInfoPrefs.ShowAccountNumbers</Name>
+          <Value>false</Value>
         </NameValue>
       </OtherPrefs>
     </Preferences>

--- a/spec/lib/quickbooks/model/preferences_spec.rb
+++ b/spec/lib/quickbooks/model/preferences_spec.rb
@@ -13,6 +13,7 @@ describe "Quickbooks::Model::Preferences" do
     preferences.email_messages.invoice_message.subject.should == "Invoice from Demo Company"
     preferences.email_messages.estimate_message.message.should include("We look forward to working with you.")
 
+    preferences.sales_forms.auto_apply_credit?.should be_true
     preferences.sales_forms.custom_fields.should_not be_empty
     preferences.sales_forms.custom_fields[0].name.should == "SalesFormsPrefs.UseSalesCustom1"
     preferences.sales_forms.custom_fields[3].name.should == "SalesFormsPrefs.SalesCustomName1"


### PR DESCRIPTION
I needed to check the AutoApplyCredit value and realized it wasn't present in the model. I went through [the docs](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/most-commonly-used/preferences#the-preferences-object) for that object and pulled all the current  fields in the SalesFormsPref section.