### PR TITLE
Added customer.tax_exemption_reason_id

### DIFF
--- a/lib/quickbooks/model/customer.rb
+++ b/lib/quickbooks/model/customer.rb
@@ -55,6 +55,7 @@ module Quickbooks
       xml_accessor :default_tax_code_ref, :from => 'DefaultTaxCodeRef', :as => BaseReference
       xml_accessor :notes, :from => 'Notes'
       xml_accessor :currency_ref, :from => 'CurrencyRef', :as => BaseReference
+      xml_accessor :tax_exemption_reason_id, :from => 'TaxExemptionReasonId'
 
       #== Validations
       validate :names_cannot_contain_invalid_characters


### PR DESCRIPTION
If `customer.taxable` is true, you need to now set `customer.tax_exemption_reason_id`. 

Docs reference: https://developer.intuit.com/app/developer/qbo/docs/api/accounting/most-commonly-used/customer#the-customer-object

<img width="725" alt="Screen Shot 2019-12-09 at 11 25 58 PM" src="https://user-images.githubusercontent.com/473529/70498209-4a019880-1adb-11ea-8b31-d470b21bc2c5.png">
