### PR TITLE
Fix Content-Type in send sales receipt

### DIFF
--- a/lib/quickbooks/service/sales_receipt.rb
+++ b/lib/quickbooks/service/sales_receipt.rb
@@ -15,7 +15,7 @@ module Quickbooks
       def send(sr, email_address=nil)
         query = email_address.present? ? "?sendTo=#{email_address}" : ""
         url = "#{url_for_resource(model::REST_RESOURCE)}/#{sr.id}/send#{query}"
-        response = do_http_post(url,{})
+        response = do_http_post(url, "", {}, { 'Content-Type' => 'application/octet-stream' })
         if response.code.to_i == 200
           model.from_xml(parse_singular_entity_response(model, response.plain_body))
         else


### PR DESCRIPTION
Fixes the `undefined method 'bytesize' for #<Hash...` error triggered when
sending a sales receipt.

Searched around and found #412  which implemented the fix for sending invoices, but hadn't been implemented for sales receipt yet.