### PR TITLE
Remove old oauth_v1 check

### DIFF
--- a/lib/quickbooks/service/access_token.rb
+++ b/lib/quickbooks/service/access_token.rb
@@ -3,8 +3,7 @@ module Quickbooks
     class AccessToken < BaseService
 
       RENEW_URL = "https://appcenter.intuit.com/api/v1/connection/reconnect"
-      DISCONNECT_URL_OAUTH1 = "https://appcenter.intuit.com/api/v1/connection/disconnect"
-      DISCONNECT_URL_OAUTH2 = "https://developer.api.intuit.com/v2/oauth2/tokens/revoke"
+      DISCONNECT_URL = "https://developer.api.intuit.com/v2/oauth2/tokens/revoke"
 
       # https://developer.intuit.com/docs/0025_quickbooksapi/0053_auth_auth/oauth_management_api#Reconnect
       def renew
@@ -22,26 +21,18 @@ module Quickbooks
 
       # https://developer.intuit.com/docs/0025_quickbooksapi/0053_auth_auth/oauth_management_api#Disconnect
       def disconnect
-        if oauth_v1?
-          response = do_http_get(DISCONNECT_URL_OAUTH1)
-          if response && response.code.to_i == 200
-            Quickbooks::Model::AccessTokenResponse.from_xml(response.plain_body)
-          end
-        elsif oauth_v2?
-          conn = Faraday.new
-          conn.basic_auth oauth.client.id, oauth.client.secret
-          response = conn.post(DISCONNECT_URL_OAUTH2, token: oauth.refresh_token || oauth.token)
+        conn = Faraday.new
+        conn.basic_auth oauth.client.id, oauth.client.secret
+        response = conn.post(DISCONNECT_URL, token: oauth.refresh_token || oauth.token)
 
-          if response.success?
-            Quickbooks::Model::AccessTokenResponse.new(error_code: "0")
-          else
-            Quickbooks::Model::AccessTokenResponse.new(
-              error_code: response.status.to_s, error_message: response.reason_phrase
-            )
-          end
+        if response.success?
+          Quickbooks::Model::AccessTokenResponse.new(error_code: "0")
+        else
+          Quickbooks::Model::AccessTokenResponse.new(
+            error_code: response.status.to_s, error_message: response.reason_phrase
+          )
         end
       end
-
     end
   end
 end

--- a/spec/lib/quickbooks/service/access_token_spec.rb
+++ b/spec/lib/quickbooks/service/access_token_spec.rb
@@ -44,23 +44,20 @@ describe Quickbooks::Service::AccessToken do
     expect(response.error_message).to eq("Invalid App Token")
   end
 
-  if ENV["OAUTH2"] == "1"
-    it "can successfully disconnect [oauth2]" do
-      xml = fixture("disconnect_200.xml")
-      stub_http_request(:get, Quickbooks::Service::AccessToken::DISCONNECT_URL_OAUTH2, ["200", "OK"], xml, {}, true)
+  it "can successfully disconnect [oauth2]" do
+    xml = fixture("disconnect_200.xml")
+    stub_http_request(:post, Quickbooks::Service::AccessToken::DISCONNECT_URL, ["200", "OK"], xml, {}, true)
 
-      response = @service.disconnect
-      expect(response.error?).to eq(false)
-    end
-
-    it "can fail to disconnect if the auth token is invalid [oauth2]" do
-      stub_http_request(:get, Quickbooks::Service::AccessToken::DISCONNECT_URL_OAUTH2, ["400", "Bad Request"], "", {}, true)
-
-      response = @service.disconnect
-      expect(response.error?).to eq(true)
-      expect(response.error_code).to    eq("400")
-      expect(response.error_message).to eq("Bad Request")
-    end
+    response = @service.disconnect
+    expect(response.error?).to eq(false)
   end
 
+  it "can fail to disconnect if the auth token is invalid [oauth2]" do
+    stub_http_request(:post, Quickbooks::Service::AccessToken::DISCONNECT_URL, ["400", "Bad Request"], "", {}, true)
+
+    response = @service.disconnect
+    expect(response.error?).to eq(true)
+    expect(response.error_code).to    eq("400")
+    expect(response.error_message).to eq("Bad Request")
+  end
 end


### PR DESCRIPTION
# Description
The `#oauth_v1?` method was removed and the `#oauth_v2?` method was commented out. And it causes exceptions when trying to disconnect.

# Fixes
https://github.com/ruckus/quickbooks-ruby/issues/501