### PR TITLE
Release 1.0.5

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,16 @@
+## 1.0.5 (2020-01-28)
+
+* Fixed Disconnect (dependency on oauth_v1? which was removed in 1.0.2)
+
+## 1.0.4 (2020-01-22)
+
+* Add ability to download credit memo as pdf
+
+## 1.0.3 (2020-01-08)
+
+* Added customer.tax_exemption_reason_id
+* fix Content-Type in send sales receipt
+
 ## 1.0.2 (2019-12-19)
 
 * Dropped OAuth1 support

--- a/lib/quickbooks/version.rb
+++ b/lib/quickbooks/version.rb
@@ -1,5 +1,5 @@
 module Quickbooks
 
-  VERSION = "1.0.2"
+  VERSION = "1.0.5"
 
 end


### PR DESCRIPTION
I filled in the details since I needed 7f7bee7efaf458d5f3d04ed0f741d81d8f70575c and am working on https://github.com/minimul/quickbooks-ruby-base/compare/master...RepairShopr:oauth2 and was blocked on including `quickbooks-ruby` via git/commit because `Quickbooks::VERSION` was still '1.0.2'