### PR TITLE
fix fetch_by_id in purchase order service

### DIFF
--- a/lib/quickbooks/service/purchase_order.rb
+++ b/lib/quickbooks/service/purchase_order.rb
@@ -7,7 +7,7 @@ module Quickbooks
       end
 
       def fetch_by_id(id, params = {})
-        url = "#{url_for_base}/invoice/#{id}?minorversion=#{Quickbooks::Model::PurchaseOrder::MINORVERSION}"
+        url = "#{url_for_base}/purchaseorder/#{id}?minorversion=#{Quickbooks::Model::PurchaseOrder::MINORVERSION}"
         fetch_object(model, url, params)
       end
 


### PR DESCRIPTION
Commit 0c9eb72 broke `fetch_by_id` in the `PurchaseOrder` service. Using the method would result in: `Object Not Found : TxnType does not match read: Purchase Order expected: Invoice`.

This was due to fetch_by_id using the invoice endpoint instead of the purchase order endpoint.