### PR TITLE
Add callbacks around HTTP requests

### DIFF
--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -253,7 +253,7 @@ module Quickbooks
         log "REQUEST HEADERS = #{headers.inspect}"
 
         request_info = RequestInfo.new(url, headers, body, method)
-        before_request&.call(request_info)
+        before_request.call(request_info) if before_request
 
         raw_response = with_around_request(request_info) do
           case method
@@ -268,7 +268,7 @@ module Quickbooks
           end
         end
 
-        after_request&.call(request_info, raw_response.body)
+        after_request.call(request_info, raw_response.body) if after_request
 
         response = Quickbooks::Service::Responses::OAuthHttpResponse.wrap(raw_response)
         log "------ QUICKBOOKS-RUBY RESPONSE ------"

--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -9,6 +9,9 @@ module Quickbooks
       attr_reader :base_uri
       attr_reader :last_response_xml
       attr_reader :last_response_intuit_tid
+      attr_accessor :before_request
+      attr_accessor :around_request
+      attr_accessor :after_request
 
       XML_NS = %{xmlns="http://schema.intuit.com/finance/v3"}
       HTTP_CONTENT_TYPE = 'application/xml'
@@ -16,6 +19,8 @@ module Quickbooks
       HTTP_ACCEPT_ENCODING = 'gzip, deflate'
       BASE_DOMAIN = 'quickbooks.api.intuit.com'
       SANDBOX_DOMAIN = 'sandbox-quickbooks.api.intuit.com'
+
+      RequestInfo = Struct.new(:url, :headers, :body, :method)
 
       def initialize(attributes = {})
         domain = Quickbooks.sandbox_mode ? SANDBOX_DOMAIN : BASE_DOMAIN
@@ -247,16 +252,23 @@ module Quickbooks
         log_request_body(body)
         log "REQUEST HEADERS = #{headers.inspect}"
 
-        raw_response = case method
-        when :get
-          oauth_get(url, headers)
-        when :post
-          oauth_post(url, body, headers)
-        when :upload
-          oauth_post_with_multipart(url, body, headers)
-        else
-          raise "Do not know how to perform that HTTP operation"
+        request_info = RequestInfo.new(url, headers, body, method)
+        before_request&.call(request_info)
+
+        raw_response = with_around_request(request_info) do
+          case method
+          when :get
+            oauth_get(url, headers)
+          when :post
+            oauth_post(url, body, headers)
+          when :upload
+            oauth_post_with_multipart(url, body, headers)
+          else
+            raise "Do not know how to perform that HTTP operation"
+          end
         end
+
+        after_request&.call(request_info, raw_response.body)
 
         response = Quickbooks::Service::Responses::OAuthHttpResponse.wrap(raw_response)
         log "------ QUICKBOOKS-RUBY RESPONSE ------"
@@ -429,6 +441,13 @@ module Quickbooks
         error
       end
 
+      def with_around_request(request_info, &block)
+        if around_request
+          around_request.call(request_info, &block)
+        else
+          block.call
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Add `before_request`, `around_request` and `after_request` callbacks around HTTP requests. This is useful for instrumentation, logging / metric gathering or controlling rate limits.

Inspiration from https://github.com/waynerobinson/xeroizer/pull/251 and https://github.com/waynerobinson/xeroizer/pull/344