### PR TITLE
Add TxnTaxDetail to Bill

### DIFF
--- a/lib/quickbooks/model/bill.rb
+++ b/lib/quickbooks/model/bill.rb
@@ -16,6 +16,7 @@ module Quickbooks
       xml_accessor :department_ref, :from => 'DepartmentRef', :as => BaseReference
 
       xml_accessor :line_items, :from => 'Line', :as => [BillLineItem]
+      xml_accessor :txn_tax_detail, :from => 'TxnTaxDetail', :as => TransactionTaxDetail
 
       xml_accessor :private_note, :from => 'PrivateNote'
 

--- a/spec/fixtures/bill_txn_tax_detail.xml
+++ b/spec/fixtures/bill_txn_tax_detail.xml
@@ -1,0 +1,46 @@
+<Bill domain="QBO" sparse="false">
+  <Id>292</Id>
+  <SyncToken>0</SyncToken>
+  <MetaData>
+    <CreateTime>2020-03-07T23:08:50-08:00</CreateTime>
+    <LastUpdatedTime>2020-03-07T23:08:50-08:00</LastUpdatedTime>
+  </MetaData>
+  <DocNumber>PO000H1</DocNumber>
+  <TxnDate>2020-03-08</TxnDate>
+  <CurrencyRef name="United States Dollar">USD</CurrencyRef>
+  <ExchangeRate>1</ExchangeRate>
+  <PrivateNote>This is a private note</PrivateNote>
+  <Line>
+    <Id>1</Id>
+    <LineNum>1</LineNum>
+    <Description>Large Mens Silver Watch</Description>
+    <Amount>400.00</Amount>
+    <DetailType>ItemBasedExpenseLineDetail</DetailType>
+    <ItemBasedExpenseLineDetail>
+      <ItemRef name="MW-001 - Mens Silver Watch">28</ItemRef>
+      <UnitPrice>400</UnitPrice>
+      <Qty>1</Qty>
+      <TaxCodeRef>9</TaxCodeRef>
+      <BillableStatus>NotBillable</BillableStatus>
+    </ItemBasedExpenseLineDetail>
+  </Line>
+  <TxnTaxDetail>
+    <TotalTax>20.00</TotalTax>
+    <TaxLine>
+      <Amount>20.00</Amount>
+      <DetailType>TaxLineDetail</DetailType>
+      <TaxLineDetail>
+        <TaxRateRef>17</TaxRateRef>
+        <PercentBased>true</PercentBased>
+        <TaxPercent>5</TaxPercent>
+        <NetAmountTaxable>400.00</NetAmountTaxable>
+      </TaxLineDetail>
+    </TaxLine>
+  </TxnTaxDetail>
+  <VendorRef name="John Doe">87</VendorRef>
+  <APAccountRef name="Accounts Payable (A/P) - USD">112</APAccountRef>
+  <TotalAmt>420.00</TotalAmt>
+  <GlobalTaxCalculation>TaxExcluded</GlobalTaxCalculation>
+  <DueDate>2020-03-22</DueDate>
+  <Balance>420.00</Balance>
+</Bill>

--- a/spec/lib/quickbooks/model/bill_spec.rb
+++ b/spec/lib/quickbooks/model/bill_spec.rb
@@ -51,6 +51,21 @@ describe "Quickbooks::Model::Bill" do
     expect(linked_txn1.bill_payment_check_type?).to eq true
   end
 
+  it "can parse a bill with TxnTaxDetail from XML" do
+    xml = fixture("bill_txn_tax_detail.xml")
+    bill = Quickbooks::Model::Bill.from_xml(xml)
+    txn_tax_detail = bill.txn_tax_detail
+    expect(txn_tax_detail.total_tax).to eq(20)
+
+    tax_line = txn_tax_detail.lines.first
+    expect(tax_line.amount).to eq(20)
+    expect(tax_line.detail_type).to eq("TaxLineDetail")
+    expect(tax_line.tax_line_detail.tax_rate_ref.value).to eq("17")
+    expect(tax_line.tax_line_detail.percent_based?).to be true
+    expect(tax_line.tax_line_detail.tax_percent).to eq(5)
+    expect(tax_line.tax_line_detail.net_amount_taxable).to eq(400)
+  end
+
   describe "#global_tax_calculation" do
     subject { Quickbooks::Model::Bill.new }
     it_should_behave_like "a model with a valid GlobalTaxCalculation", "TaxInclusive"


### PR DESCRIPTION
[API Reference for Bill](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/most-commonly-used/bill)

Example Payload:
```xml
<Bill domain="QBO" sparse="false">
  ...
  <TxnTaxDetail>
    <TotalTax>20.00</TotalTax>
    <TaxLine>
      <Amount>20.00</Amount>
      <DetailType>TaxLineDetail</DetailType>
      <TaxLineDetail>
        <TaxRateRef>17</TaxRateRef>
        <PercentBased>true</PercentBased>
        <TaxPercent>5</TaxPercent>
        <NetAmountTaxable>400.00</NetAmountTaxable>
      </TaxLineDetail>
    </TaxLine>
  </TxnTaxDetail>
  ...
</Bill>
```

Example usage:
```ruby
bill.txn_tax_detail.total_tax # 20
bill.txn_tax_detail.lines.first.amount # 20
```