### PR TITLE
Escape regex matching numbers in report parsing

### DIFF
--- a/lib/quickbooks/model/report.rb
+++ b/lib/quickbooks/model/report.rb
@@ -38,7 +38,7 @@ module Quickbooks
           value = el.attr('value')
 
           next nil if value.blank?
-          next value if value.to_s.match(/^\d+$|^\d+.\d+$|^-\d+|^-\d+.\d+$|^.\d+$/).nil?
+          next value if value.to_s.match(/^\d+$|^\d+\.\d+$|^-\d+|^-\d+\.\d+$|^\.\d+$/).nil?
           BigDecimal(value)
         end
       end


### PR DESCRIPTION
`.` will match anything, not just the literal character.  This means that the regex that is attempting to filter only numbers will match unexpected strings, such as "T1", which matches `/^.\d+$/`, but does not match `^\.\d+$/`
Previously when values such as "T1" appear in a report, an exception will be raised by BigDecimal because it cannot parse the value