### PR TITLE
Raise IntuitRequestException for unhandled status code

### DIFF
--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -346,7 +346,7 @@ module Quickbooks
         when 502, 503, 504
           raise Quickbooks::ServiceUnavailable
         else
-          raise "HTTP Error Code: #{status}, Msg: #{response.plain_body}"
+          raise Quickbooks::IntuitRequestException.new("HTTP Error Code: #{status}, Msg: #{response.plain_body}")
         end
       end
 

--- a/spec/lib/quickbooks/service/base_service_spec.rb
+++ b/spec/lib/quickbooks/service/base_service_spec.rb
@@ -151,6 +151,13 @@ describe Quickbooks::Service::BaseService do
       response = Struct.new(:code, :plain_body).new(504, xml)
       expect { @service.send(:check_response, response) }.to raise_error(Quickbooks::ServiceUnavailable)
     end
+
+    it "should raise IntuitRequestException on unhandled status code" do
+      xml = fixture('generic_error.xml')
+
+      response = Struct.new(:code, :plain_body).new(1000, xml)
+      expect { @service.send(:check_response, response) }.to raise_error(Quickbooks::IntuitRequestException)
+    end
   end
 
   it "Correctly handled an IntuitRequestException" do


### PR DESCRIPTION
When there's an unhandled status code, raise `Quickbooks::IntuitRequestException` instead of `RuntimeError` to allow better error handling on client side.