### PR TITLE
Fix NoMethodError when response headers are nil

### DIFF
--- a/lib/quickbooks/faraday/middleware/gzip.rb
+++ b/lib/quickbooks/faraday/middleware/gzip.rb
@@ -23,6 +23,8 @@ class Gzip < Faraday::Middleware
   def call(env)
     env[:request_headers][ACCEPT_ENCODING] ||= SUPPORTED_ENCODINGS
     @app.call(env).on_complete do |response_env|
+      break if response_env[:response_headers].nil?
+
       case response_env[:response_headers][CONTENT_ENCODING]
       when 'gzip'
         reset_body(response_env, &method(:uncompress_gzip))


### PR DESCRIPTION
When response headers are nil, do not decompress to prevent `NoMethodError: undefined method [] for nil:NilClass`. Issue https://github.com/ruckus/quickbooks-ruby/issues/512