### PR TITLE
Update Readme about roxml BigDecimal deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ This has been tested on 2.x
 
 Ruby 1.9.x is not supported.
 
+Ruby 2.7.0 is not supported due to roxml dependancy issue
+
 ## Dependencies
 
 Gems:


### PR DESCRIPTION
BigDecimal deprecation in ruby 2.7.0 breaks roxml dependency on this gem

https://github.com/ruckus/quickbooks-ruby/issues/515
https://github.com/Empact/roxml/issues/64