### PR TITLE
Loosen roxml version constraint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ rvm:
   - 2.3.0
   - 2.4.0
   - 2.5.0
+  - 2.6.0
+  - 2.7.0
 # Bundler 1.13 added support for `ruby RUBY_VERSION` in the Gemfile
 before_install: gem install bundler -v '1.17.3'
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ This has been tested on 2.x
 
 Ruby 1.9.x is not supported.
 
-Ruby 2.7.0 is not supported due to roxml dependancy issue
-
 ## Dependencies
 
 Gems:

--- a/quickbooks-ruby.gemspec
+++ b/quickbooks-ruby.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.files = Dir['lib/**/*']
 
   gem.add_dependency 'oauth2', '~>1.4'
-  gem.add_dependency 'roxml', '4.0.0'
+  gem.add_dependency 'roxml', '~> 4.0'
   gem.add_dependency 'activemodel', '> 4.0'
   gem.add_dependency 'nokogiri'  # promiscuous mode
   gem.add_dependency 'multipart-post' # promiscuous mode


### PR DESCRIPTION
Prior to this PR, the `quickbooks-ruby` gem has declared a version constraint for the `roxml` gem of exactly `'4.0.0'`. This means that applications using `quickbooks-ruby` are unable to use a later version of roxml (such as the [recently released `roxml v4.1.0`]).

To fix this problem, I've loosened the `roxml` version constraint to `'~> 4.0'`, which makes it compatible with any minor versions of `4.x`.

I didn't choose `'>= 4.0'` because it's possible that `roxml` would release a `5.x` version with a breaking change that would not be compatible with `quickbooks-ruby`. But as long as `roxml` follows semver, it should be safe to change this to `'~> 4.0'`.

[recently released `roxml v4.1.0`]: https://rubygems.org/gems/roxml/versions/4.1.0