### PR TITLE
Bugfix: Do not match percent sign when parsing Report rows

### DIFF
--- a/lib/quickbooks/model/report.rb
+++ b/lib/quickbooks/model/report.rb
@@ -38,7 +38,7 @@ module Quickbooks
           value = el.attr('value')
 
           next nil if value.blank?
-          next value if value.to_s.match(/^\d+$|^\d+\.\d+$|^-\d+|^-\d+\.\d+$|^\.\d+$/).nil?
+          next value if value.to_s.match(/^\d+$|^\d+\.\d+$|^-\d+$|^-\d+\.\d+$|^\.\d+$/).nil?
           BigDecimal(value)
         end
       end

--- a/lib/quickbooks/service/purchase_order.rb
+++ b/lib/quickbooks/service/purchase_order.rb
@@ -7,7 +7,7 @@ module Quickbooks
       end
 
       def fetch_by_id(id, params = {})
-        url = "#{url_for_base}/invoice/#{id}?minorversion=#{Quickbooks::Model::PurchaseOrder::MINORVERSION}"
+        url = "#{url_for_base}/purchaseorder/#{id}?minorversion=#{Quickbooks::Model::PurchaseOrder::MINORVERSION}"
         fetch_object(model, url, params)
       end
 


### PR DESCRIPTION
## Issue
Getting an `invalid value for BigDecimal()` error when trying to parse percentages like "-51.71 %".

## Change
Fix third alternative in regex to not match negative numbers with trailing non digit characters
