### PR TITLE
added ship from address reference to invoice

### DIFF
--- a/lib/quickbooks/model/invoice.rb
+++ b/lib/quickbooks/model/invoice.rb
@@ -36,6 +36,7 @@ module Quickbooks
       xml_accessor :customer_memo, :from => 'CustomerMemo'
       xml_accessor :billing_address, :from => 'BillAddr', :as => PhysicalAddress
       xml_accessor :shipping_address, :from => 'ShipAddr', :as => PhysicalAddress
+      xml_accessor :ship_from_address, :from => 'ShipFromAddr', :as => PhysicalAddress
       xml_accessor :class_ref, :from => 'ClassRef', :as => BaseReference
       xml_accessor :sales_term_ref, :from => 'SalesTermRef', :as => BaseReference
       xml_accessor :due_date, :from => 'DueDate', :as => Date

--- a/spec/fixtures/invoice.xml
+++ b/spec/fixtures/invoice.xml
@@ -72,6 +72,16 @@
 		<Lat>33.739466</Lat>
 		<Long>-118.0395574</Long>
 	</ShipAddr>
+	<ShipFromAddr>
+		<Id>5</Id>
+		<Line1>1040 East Tasman Drive.</Line1>
+		<City>Los Angeles</City>
+		<Country>USA</Country>
+		<CountrySubDivisionCode>CA</CountrySubDivisionCode>
+		<PostalCode>91123</PostalCode>
+		<Lat>33.739466</Lat>
+		<Long>-118.0395574</Long>
+	</ShipFromAddr>
 	<SalesTermRef>2</SalesTermRef>
 	<DueDate>2013-11-30</DueDate>
 	<TotalAmt>50.00</TotalAmt>

--- a/spec/lib/quickbooks/model/invoice_spec.rb
+++ b/spec/lib/quickbooks/model/invoice_spec.rb
@@ -56,6 +56,17 @@ describe "Quickbooks::Model::Invoice" do
     expect(shipping_address.postal_code).to eq "91123"
     expect(shipping_address.lat).to eq "33.739466"
     expect(shipping_address.lon).to eq "-118.0395574"
+    
+    ship_from_address = invoice.ship_from_address
+    expect(ship_from_address).to_not be_nil
+    expect(ship_from_address.id).to eq "5"
+    expect(ship_from_address.line1).to eq "1040 East Tasman Drive."
+    expect(ship_from_address.city).to eq "Los Angeles"
+    expect(ship_from_address.country).to eq "USA"
+    expect(ship_from_address.country_sub_division_code).to eq "CA"
+    expect(ship_from_address.postal_code).to eq "91123"
+    expect(ship_from_address.lat).to eq "33.739466"
+    expect(ship_from_address.lon).to eq "-118.0395574"
 
     tax_detail = invoice.txn_tax_detail
     expect(tax_detail.total_tax).to eq(2.85)


### PR DESCRIPTION
I have added a reference in the Invoice model for ShipFromAddr (ship_from_address).  This was missing and something my organization needed to access