### PR TITLE
Per #539, add pdf function for purchase orders

### DIFF
--- a/lib/quickbooks/service/purchase_order.rb
+++ b/lib/quickbooks/service/purchase_order.rb
@@ -16,6 +16,12 @@ module Quickbooks
         "#{url}&minorversion=#{Quickbooks.minorversion}"
       end
 
+      def pdf(purchase_order)
+        url = "#{url_for_resource(model::REST_RESOURCE)}/#{purchase_order.id}/pdf"
+        response = do_http_raw_get(url, {}, {'Accept' => 'application/pdf'})
+        response.plain_body
+      end
+
     private
 
       def model


### PR DESCRIPTION
Quickbooks now supports fetching PDFs of Purchase Orders. 