### PR TITLE
fix: Reject strings with newlines as being numeric.

### DIFF
--- a/lib/quickbooks/model/report.rb
+++ b/lib/quickbooks/model/report.rb
@@ -38,9 +38,13 @@ module Quickbooks
           value = el.attr('value')
 
           next nil if value.blank?
-          next value if value.to_s.match(/^\d+$|^\d+\.\d+$|^-\d+$|^-\d+\.\d+$|^\.\d+$/).nil?
+          next value unless numeric?(value)
           BigDecimal(value)
         end
+      end
+
+      def numeric?(value)
+        BigDecimal(value) != nil rescue false
       end
 
     end

--- a/spec/fixtures/transaction_list_report.xml
+++ b/spec/fixtures/transaction_list_report.xml
@@ -1,0 +1,100 @@
+<Report xmlns="http://schema.intuit.com/finance/v3">
+  <Header>
+    <Time>2021-02-08T03:41:24-08:00</Time>
+    <ReportName>TransactionList</ReportName>
+    <StartPeriod>2021-01-01</StartPeriod>
+    <EndPeriod>2021-12-31</EndPeriod>
+    <Currency>CAD</Currency>
+    <Option>
+      <Name>NoReportData</Name>
+      <Value>false</Value>
+    </Option>
+  </Header>
+  <Columns>
+    <Column>
+      <ColTitle>Date</ColTitle>
+      <ColType>Date</ColType>
+      <MetaData>
+        <Name>ColKey</Name>
+        <Value>tx_date</Value>
+      </MetaData>
+    </Column>
+    <Column>
+      <ColTitle>Transaction Type</ColTitle>
+      <ColType>String</ColType>
+      <MetaData>
+        <Name>ColKey</Name>
+        <Value>txn_type</Value>
+      </MetaData>
+    </Column>
+    <Column>
+      <ColTitle>#</ColTitle>
+      <ColType>String</ColType>
+      <MetaData>
+        <Name>ColKey</Name>
+        <Value>doc_num</Value>
+      </MetaData>
+    </Column>
+    <Column>
+      <ColTitle>Posting</ColTitle>
+      <ColType>Boolean</ColType>
+      <MetaData>
+        <Name>ColKey</Name>
+        <Value>is_no_post</Value>
+      </MetaData>
+    </Column>
+    <Column>
+      <ColTitle>Name</ColTitle>
+      <ColType>String</ColType>
+      <MetaData>
+        <Name>ColKey</Name>
+        <Value>name</Value>
+      </MetaData>
+    </Column>
+    <Column>
+      <ColTitle>Memo/Description</ColTitle>
+      <ColType>String</ColType>
+      <MetaData>
+        <Name>ColKey</Name>
+        <Value>memo</Value>
+      </MetaData>
+    </Column>
+    <Column>
+      <ColTitle>Account</ColTitle>
+      <ColType>String</ColType>
+      <MetaData>
+        <Name>ColKey</Name>
+        <Value>account_name</Value>
+      </MetaData>
+    </Column>
+    <Column>
+      <ColTitle>Split</ColTitle>
+      <ColType>String</ColType>
+      <MetaData>
+        <Name>ColKey</Name>
+        <Value>other_account</Value>
+      </MetaData>
+    </Column>
+    <Column>
+      <ColTitle>Amount</ColTitle>
+      <ColType>Money</ColType>
+      <MetaData>
+        <Name>ColKey</Name>
+        <Value>subt_nat_amount</Value>
+      </MetaData>
+    </Column>
+  </Columns>
+  <Rows>
+    <Row type="Data">
+      <ColData value="2020-01-01"/>
+      <ColData value="Invoice" id="100"/>
+      <ColData value="10&#10;ID#112233"/>
+      <ColData value="Yes"/>
+      <ColData value="Vendor" id="12"/>
+      <ColData value=""/>
+      <ColData value="0100 Accounts Receivable (A/R)" id="67"/>
+      <ColData value="-Split-" id=""/>
+      <ColData value="300.00"/>
+    </Row>
+  </Rows>
+</Report>

--- a/spec/lib/quickbooks/model/report_spec.rb
+++ b/spec/lib/quickbooks/model/report_spec.rb
@@ -8,6 +8,7 @@ describe Quickbooks::Model::Report do
   let(:report) { build_report("balancesheet.xml") }
   let(:report_with_years) { build_report("balance_sheet_with_year_summary.xml") }
   let(:age_payable_report) { build_report("age_payable_detail.xml") }
+  let(:transaction_list_report) { build_report("transaction_list_report.xml") }
 
   describe "#xml" do
     it 'exposes the full xml response' do
@@ -53,6 +54,10 @@ describe Quickbooks::Model::Report do
       expect(age_payable_report.all_rows[2]).to eq(['2018-05-18', 'Bill', nil, 'Robot Parts', '2016-05-28', BigDecimal('100'), BigDecimal('100'), BigDecimal('100')])
       expect(age_payable_report.all_rows[3]).to eq(['Total', nil, nil, nil, nil, nil, BigDecimal('.00'), BigDecimal('.00')])
       expect(age_payable_report.all_rows[4]).to eq(['TOTAL', nil, nil, nil, nil, nil, BigDecimal('.00'), BigDecimal('.00')])
+    end
+
+    it 'works with columns that have newlines' do
+      expect(transaction_list_report.all_rows[0]).to eq(["2020-01-01", "Invoice", "10\nID#112233", "Yes", "Vendor", nil, "0100 Accounts Receivable (A/R)", "-Split-", 0.3e3])
     end
   end
 


### PR DESCRIPTION
We ran into a production case where an invoice number contained a newline character. The current method of detecting if the string that contained the newline was returning that the string was in fact numeric when it wasn't. This caused the call to `BigNumber` to raise an exception.

The proposed fix is to try to parse the value as a BigNumber and if it false use the string value.