### PR TITLE
Allow Faraday adapter to be configured

### DIFF
--- a/lib/quickbooks-ruby.rb
+++ b/lib/quickbooks-ruby.rb
@@ -194,6 +194,7 @@ module Quickbooks
   @@sandbox_mode = false
   @@logger = nil
   @@minorversion = 47
+  @@http_adapter = :net_http
 
   class << self
     def sandbox_mode
@@ -218,6 +219,14 @@ module Quickbooks
 
     def logger=(logger)
       @@logger = logger
+    end
+
+    def http_adapter
+      @@http_adapter
+    end
+
+    def http_adapter=(adapter)
+      @@http_adapter = adapter
     end
 
     # set logging on or off

--- a/lib/quickbooks/service/access_token.rb
+++ b/lib/quickbooks/service/access_token.rb
@@ -1,7 +1,6 @@
 module Quickbooks
   module Service
     class AccessToken < BaseService
-
       RENEW_URL = "https://appcenter.intuit.com/api/v1/connection/reconnect"
       DISCONNECT_URL = "https://developer.api.intuit.com/v2/oauth2/tokens/revoke"
 
@@ -21,10 +20,14 @@ module Quickbooks
 
       # https://developer.intuit.com/docs/0025_quickbooksapi/0053_auth_auth/oauth_management_api#Disconnect
       def disconnect
-        conn = Faraday.new
-        conn.basic_auth oauth.client.id, oauth.client.secret
+        connection = Faraday.new do |f|
+          f.adapter ::Quickbooks.http_adapter
+          f.request :url_encoded
+          f.basic_auth(oauth.client.id, oauth.client.secret)
+        end
+
         url = "#{DISCONNECT_URL}?minorversion=#{Quickbooks.minorversion}"
-        response = conn.post(url, token: oauth.refresh_token || oauth.token)
+        response = connection.post(url, token: oauth.refresh_token || oauth.token)
 
         if response.success?
           Quickbooks::Model::AccessTokenResponse.new(error_code: "0")

--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -54,7 +54,7 @@ module Quickbooks
           builder.use :gzip
           builder.request :multipart
           builder.request :url_encoded
-          builder.adapter :net_http_persistent
+          builder.adapter ::Quickbooks.http_adapter
         end
       end
 

--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -54,7 +54,7 @@ module Quickbooks
           builder.use :gzip
           builder.request :multipart
           builder.request :url_encoded
-          builder.adapter :net_http
+          builder.adapter :net_http_persistent
         end
       end
 

--- a/quickbooks-ruby.gemspec
+++ b/quickbooks-ruby.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency "webmock"
   gem.add_development_dependency 'dotenv'
+  gem.add_development_dependency 'net-http-persistent'
 end

--- a/spec/lib/quickbooks_spec.rb
+++ b/spec/lib/quickbooks_spec.rb
@@ -5,4 +5,9 @@ describe Quickbooks do
     it { is_expected.to be_a String }
   end
 
+  describe '.http_version=' do
+    subject { Quickbooks.http_adapter = :net_http_persistent }
+
+    it { expect { subject }.to change { Quickbooks.http_adapter }.from(:net_http).to(:net_http_persistent) }
+  end
 end


### PR DESCRIPTION
We want to be able to parallelize some the work that we do with `quickbooks-ruby`, but `Net::HTTP` is not thread-safe. To ensure thread-safety, we want to use Faraday's `net-http-persistent` adapter, instead.

This PR allows developers using the gem to choose which Faraday adapter to use.

The default is still `:net_http`, but you can now set: `Quickbooks.http_adapter`.