### PR TITLE
Fixes #439 - Don't quote boolean values in queries

### DIFF
--- a/lib/quickbooks/service/service_crud.rb
+++ b/lib/quickbooks/service/service_crud.rb
@@ -33,7 +33,10 @@ module Quickbooks
         if field.class == Symbol
           field = field.to_s.camelcase
         end
-        q = "select * from %s where %s = '%s'" % [model.resource_for_singular, field, selector]
+
+        clause = Quickbooks::Util::QueryBuilder.new.clause(field, '=', selector)
+        q = "select * from %s where %s" % [model.resource_for_singular, clause]
+
         self.query(q, options)
       end
 

--- a/lib/quickbooks/util/query_builder.rb
+++ b/lib/quickbooks/util/query_builder.rb
@@ -20,6 +20,8 @@ module Quickbooks
                   value.strftime('%Y-%m-%d')
                 when Array
                   value = value.map(&escape_single_quotes)
+                when true, false
+                  value
                 else
                   value = escape_single_quotes.call(value)
                 end
@@ -27,6 +29,8 @@ module Quickbooks
         if operator.downcase == 'in' && value.is_a?(Array)
           value = value.map { |v| "#{VALUE_QUOTE}#{v}#{VALUE_QUOTE}" }
           "#{field} #{operator} (#{value.join(', ')})"
+        elsif value == true || value == false
+          "#{field} #{operator} #{value}"
         else
           "#{field} #{operator} #{VALUE_QUOTE}#{value}#{VALUE_QUOTE}"
         end

--- a/spec/lib/quickbooks/util/query_builder_spec.rb
+++ b/spec/lib/quickbooks/util/query_builder_spec.rb
@@ -26,9 +26,15 @@ describe Quickbooks::Util::QueryBuilder do
     expect(expected).to eq generated
   end
 
-  it "converts values that aren't dates or arrays into strings" do
+  it "converts values that aren't dates or arrays or booleans into strings" do
     expected = "Id = '42'"
     generated = subject.clause("Id", "=", 42)
+    expect(expected).to eq generated
+  end
+
+  it "does not quote boolean values" do
+    expected = "active = true"
+    generated = subject.clause("active", "=", true)
     expect(expected).to eq generated
   end
 end


### PR DESCRIPTION
- Update Quickbooks::Util::QueryBuilder to handle boolean values
- Update Quickbooks::Service::ServiceCrud#find_by to use the QueryBuilder so that booleans are properly handled