### PR TITLE
Added linked_transactions to bill_line_item

### DIFF
--- a/lib/quickbooks/model/bill_line_item.rb
+++ b/lib/quickbooks/model/bill_line_item.rb
@@ -12,6 +12,8 @@ module Quickbooks
       xml_accessor :amount, :from => 'Amount', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :detail_type, :from => 'DetailType'
 
+      xml_accessor :linked_transactions, :from => 'LinkedTxn', :as => [LinkedTransaction]
+
       #== Various detail types
       xml_accessor :account_based_expense_line_detail, :from => 'AccountBasedExpenseLineDetail', :as => AccountBasedExpenseLineDetail
       xml_accessor :item_based_expense_line_detail, :from => 'ItemBasedExpenseLineDetail', :as => ItemBasedExpenseLineDetail


### PR DESCRIPTION
https://developer.intuit.com/app/developer/qbo/docs/api/accounting/most-commonly-used/bill  
'Zero or more transactions linked to this Bill object. The LinkedTxn.TxnType can be set to PurchaseOrder, BillPaymentCheck or if using Minor Version 55 and above ReimburseCharge. Use LinkedTxn.TxnId as the ID of the transaction.'