### PR TITLE
Add total_tax_specified to TransactionTaxDetailModel

### DIFF
--- a/lib/quickbooks/model/transaction_tax_detail.rb
+++ b/lib/quickbooks/model/transaction_tax_detail.rb
@@ -1,9 +1,9 @@
 module Quickbooks
   module Model
     class TransactionTaxDetail < BaseModel
-
       xml_accessor :txn_tax_code_ref, :from => 'TxnTaxCodeRef', :as => BaseReference
       xml_accessor :total_tax, :from => 'TotalTax', :as => BigDecimal, :to_xml => to_xml_big_decimal
+      xml_accessor :total_tax_specified, :from => 'TotalTaxSpecified'
       xml_accessor :lines, :from => 'TaxLine', :as => [TaxLine]
 
       reference_setters :txn_tax_code_ref

--- a/spec/lib/quickbooks/model/transaction_tax_detail_spec.rb
+++ b/spec/lib/quickbooks/model/transaction_tax_detail_spec.rb
@@ -1,19 +1,35 @@
-describe "Quickbooks::Model::TransactionTaxDetail" do
-  it "allows setting of the TxnTaxCodeRef via #txn_tax_code_ref_id=" do
-    transaction_tax_detail = Quickbooks::Model::TransactionTaxDetail.new
-    transaction_tax_detail.total_tax = 42
-    transaction_tax_detail.txn_tax_code_id = 42
-    expect(transaction_tax_detail.txn_tax_code_ref.value).to eq(42)
+describe Quickbooks::Model::TransactionTaxDetail do
+  subject(:transaction_tax_detail) { Quickbooks::Model::TransactionTaxDetail.new }
+
+  describe 'txn_tax_code_ref_id' do
+    it "allows setting of the TxnTaxCodeRef via #txn_tax_code_ref_id=" do
+      transaction_tax_detail.total_tax = 42
+      transaction_tax_detail.txn_tax_code_id = 42
+      expect(transaction_tax_detail.txn_tax_code_ref.value).to eq(42)
+    end
   end
 
-  it "total tax should be a decimal/float" do
-    transaction_tax_detail = Quickbooks::Model::TransactionTaxDetail.new
-    transaction_tax_detail.total_tax = 42
-    expect(transaction_tax_detail.to_xml.at_css('TotalTax').content).to eq('42.0')
+  describe 'total tax specified' do
+    context 'when it is set' do
+      before { transaction_tax_detail.total_tax_specified = false }
+
+      it { expect(transaction_tax_detail.to_xml.at_css('TotalTaxSpecified').content).to match('false') }
+    end
+
+    context 'when it is not set' do
+      it { expect(transaction_tax_detail.to_xml).not_to match(/TotalTaxSpecified/) }
+    end
   end
 
-  it "total tax should not be included if not set" do
-    transaction_tax_detail = Quickbooks::Model::TransactionTaxDetail.new
-    expect(transaction_tax_detail.to_xml).not_to match(/TotalTax/)
+  describe 'total tax' do
+    context 'when it is set' do
+      before { transaction_tax_detail.total_tax = 42 }
+
+      it { expect(transaction_tax_detail.to_xml.at_css('TotalTax').content).to eq('42.0') }
+    end
+
+    context 'when it is not set' do
+      it { expect(transaction_tax_detail.to_xml).not_to match(/TotalTax/) }
+    end
   end
 end


### PR DESCRIPTION
When creating or updating a QBO invoice and not specifying the `TotalTax`, we need to pass a field `TotalTaxSpecified` as false to QBO.

In total, this PR holds makes the following changes:

1. Allows us to set `TotalTaxSpecified` on the `TransactionTaxDetail`
2. Adds some specs for the above
3. Refactors some old specs for that model.

**NOTE**: We're using this internally and this is just so others are able to set it. Also, the reason this came up is described in this thread: https://help.developer.intuit.com/s/question/0D74R000004nqSK/detail?s1oid=00DG0000000COk8&s1nid=0DBG0000000blK7&emkind=chatterCommentNotification&s1uid=0054R00000B4S02&emtm=1638296091795&fromEmail=1&s1ext=0