### PR TITLE
Add explicit dependency on Faraday < 2.0

### DIFF
--- a/quickbooks-ruby.gemspec
+++ b/quickbooks-ruby.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'net-http-persistent'
   gem.add_dependency 'nokogiri'  # promiscuous mode
   gem.add_dependency 'multipart-post' # promiscuous mode
+  gem.add_dependency 'faraday', '< 2.0'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'simplecov'


### PR DESCRIPTION
Faraday made some fairly significant changes in the 2.0
update. `quickbooks-ruby` currently uses a Faraday middlware, which
[was deprecated][1] in the 2.0 update. This adds an explicit
dependency on Faraday < 2.0 rather than using whatever Faraday version
the oauth-2 gem installs.

[1]:https://github.com/lostisland/faraday/blob/main/UPGRADING.md#faraday-middleware-deprecation

Fixes #570 