### PR TITLE
Add condense logs option

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+## 1.0.18 (2021-09-09)
+
+* bump roxml version to `~ 4.2` to resolve URI deprecation issues
+
 ## 1.0.17 (2021-04-28)
 
 * Allow Faraday adapter used in quickbooks-ruby to be configurable.

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ end
 Pulled together usage is:
 
 ```ruby
+intuit_account = IntuitAccount.find(x)
 intuit_account.perform_authenticated_request do |access_token|
   # do something here, like
   service = Quickbooks::Service::Customer.new

--- a/lib/quickbooks/version.rb
+++ b/lib/quickbooks/version.rb
@@ -1,5 +1,5 @@
 module Quickbooks
 
-  VERSION = "1.0.17"
+  VERSION = "1.0.18"
 
 end

--- a/quickbooks-ruby.gemspec
+++ b/quickbooks-ruby.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.files = Dir['lib/**/*']
 
   gem.add_dependency 'oauth2', '~>1.4'
-  gem.add_dependency 'roxml', '~> 4.0'
+  gem.add_dependency 'roxml', '~> 4.2'
   gem.add_dependency 'activemodel', '> 4.0'
   gem.add_dependency 'net-http-persistent'
   gem.add_dependency 'nokogiri'  # promiscuous mode


### PR DESCRIPTION
Add an option to only call the logger once per request & once per response when talking to QBO to make searching logs in general & especially 3rd party log managers easier.