### PR TITLE
Migrate CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", ruby-head]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true # 'bundle install' and cache gems
+        ruby-version: ${{ matrix.ruby }}
+    - name: Run tests
+      run: bundle exec rake

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Join the chat at https://gitter.im/ruckus/quickbooks-ruby](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ruckus/quickbooks-ruby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-[![Build Status](https://travis-ci.org/ruckus/quickbooks-ruby.png?branch=master)](https://travis-ci.org/ruckus/quickbooks-ruby)
+![Build Status](https://github.com/ruckus/quickbooks-ruby/actions/workflows/ci.yml/badge.svg)
 
 Integration with Quickbooks Online via the Intuit Data Services v3 REST API.
 

--- a/spec/lib/quickbooks/model/account_spec.rb
+++ b/spec/lib/quickbooks/model/account_spec.rb
@@ -2,36 +2,37 @@ describe Quickbooks::Model::Account do
   it "must have a name for create / update" do
     account = Quickbooks::Model::Account.new
     account.valid?
-    expect(account.errors.keys.include?(:name)).to be true
+    expect(account.errors.map(&:attribute).include?(:name)).to be true
 
     account.name = Array.new(102).join("a") # 101 character, too long
     account.valid?
-    expect(account.errors.keys.include?(:name)).to be true
+    expect(account.errors.map(&:attribute).include?(:name)).to be true
 
     account.name = "Invalid name with :"
     account.valid?
-    expect(account.errors.keys.include?(:name)).to be true
+    expect(account.errors.map(&:attribute).include?(:name)).to be true
 
     account.name = "Invalid name with \""
     account.valid?
-    expect(account.errors.keys.include?(:name)).to be true
+    expect(account.errors.map(&:attribute).include?(:name)).to be true
 
     account.name = "Regular"
     account.valid?
-    expect(account.errors.keys.include?(:name)).to eq false
+    pp account.errors
+    expect(account.errors.map(&:attribute).include?(:name)).to be false
   end
 
   it "must have a classifiction" do
     account = Quickbooks::Model::Account.new
     account.valid?
-    expect(account.errors.keys.include?(:classification)).to be true
+    expect(account.errors.map(&:attribute).include?(:classification)).to be true
 
     account.classification = 'Undocummented Classification'
     account.valid?
-    expect(account.errors.keys.include?(:classification)).to be true
+    expect(account.errors.map(&:attribute).include?(:classification)).to be true
 
     account.classification = Quickbooks::Model::Account::LIABILITY
     account.valid?
-    expect(account.errors.keys.include?(:classification)).to eq false
+    expect(account.errors.map(&:attribute).include?(:classification)).to be false
   end
 end

--- a/spec/lib/quickbooks/model/class_spec.rb
+++ b/spec/lib/quickbooks/model/class_spec.rb
@@ -14,14 +14,14 @@ describe "Quickbooks::Model::Class" do
     classs = Quickbooks::Model::Class.new
     classs.name = "My:Class"
     expect(classs.valid?).to eq false
-    expect(classs.errors.keys).to include(:name)
+    expect(classs.errors.map(&:attribute)).to include(:name)
   end
 
   it "cannot update an invalid model" do
     classs = Quickbooks::Model::Class.new
     expect(classs.valid_for_update?).to eq false
     expect(classs.to_xml_ns).to match('Class')
-    expect(classs.errors.keys).to include(:sync_token)
+    expect(classs.errors.map(&:attribute)).to include(:sync_token)
   end
 
 end

--- a/spec/lib/quickbooks/model/credit_memo_spec.rb
+++ b/spec/lib/quickbooks/model/credit_memo_spec.rb
@@ -6,7 +6,7 @@ describe "Quickbooks::Model::CreditMemo" do
     credit_memo = Quickbooks::Model::CreditMemo.new
     expect(credit_memo.line_items).to be_kind_of(Array)
     expect(credit_memo.valid?).to be false
-    expect(credit_memo.errors.keys.include?(:line_items)).to be true
+    expect(credit_memo.errors.map(&:attribute).include?(:line_items)).to be true
   end
 
   it "should not be valid if empty line item" do

--- a/spec/lib/quickbooks/model/customer_spec.rb
+++ b/spec/lib/quickbooks/model/customer_spec.rb
@@ -59,7 +59,7 @@ describe "Quickbooks::Model::Customer" do
     customer = Quickbooks::Model::Customer.new
     expect(customer.valid_for_update?).to eq(false)
     expect(customer.to_xml_ns).to match('Customer')
-    expect(customer.errors.keys.include?(:sync_token)).to eq(true)
+    expect(customer.errors.map(&:attribute).include?(:sync_token)).to eq(true)
   end
 
   it "should handle a nil/blank email address" do

--- a/spec/lib/quickbooks/model/department_spec.rb
+++ b/spec/lib/quickbooks/model/department_spec.rb
@@ -14,14 +14,14 @@ describe "Quickbooks::Model::Department" do
     department = Quickbooks::Model::Department.new
     department.name = "This:Department"
     department.valid?
-    expect(department.errors.keys).to include(:name)
+    expect(department.errors.map(&:attribute)).to include(:name)
   end
 
   it "cannot update an invalid model" do
     department = Quickbooks::Model::Department.new
     expect(department.valid_for_update?).to eq(false)
     expect(department.to_xml_ns).to match('Department')
-    expect(department.errors.keys).to include(:sync_token)
+    expect(department.errors.map(&:attribute)).to include(:sync_token)
   end
 
 end

--- a/spec/lib/quickbooks/model/employee_spec.rb
+++ b/spec/lib/quickbooks/model/employee_spec.rb
@@ -50,14 +50,14 @@ describe "Quickbooks::Model::Employee" do
     employee = Quickbooks::Model::Employee.new
     employee.email_address = "foo+example.org"
     employee.valid?
-    expect(employee.errors.keys).to include(:primary_email_address)
+    expect(employee.errors.map(&:attribute)).to include(:primary_email_address)
   end
 
   it "cannot update an invalid model" do
     employee = Quickbooks::Model::Employee.new
     expect(employee.valid_for_update?).to eq(false)
     expect(employee.to_xml_ns).to match('Employee')
-    expect(employee.errors.keys).to include(:sync_token)
+    expect(employee.errors.map(&:attribute)).to include(:sync_token)
   end
 
 end

--- a/spec/lib/quickbooks/model/estimate_spec.rb
+++ b/spec/lib/quickbooks/model/estimate_spec.rb
@@ -72,13 +72,13 @@ describe "Quickbooks::Model::Estimate" do
   it "should require line items for create / update" do
     estimate = Quickbooks::Model::Estimate.new
     expect(estimate.valid?).to be false
-    expect(estimate.errors.keys.include?(:line_items)).to be true
+    expect(estimate.errors.map(&:attribute).include?(:line_items)).to be true
   end
 
   it "should require customer_ref for create / update" do
     estimate = Quickbooks::Model::Estimate.new
     expect(estimate.valid?).to be false
-    expect(estimate.errors.keys.include?(:customer_ref)).to be true
+    expect(estimate.errors.map(&:attribute).include?(:customer_ref)).to be true
   end
 
   it "is valid with line_items and customer_ref" do

--- a/spec/lib/quickbooks/model/invoice_spec.rb
+++ b/spec/lib/quickbooks/model/invoice_spec.rb
@@ -105,13 +105,13 @@ describe "Quickbooks::Model::Invoice" do
   it "should require line items for create / update" do
     invoice = Quickbooks::Model::Invoice.new
     expect(invoice.valid?).to be false
-    expect(invoice.errors.keys.include?(:line_items)).to be true
+    expect(invoice.errors.map(&:attribute).include?(:line_items)).to be true
   end
 
   it "should require customer_ref for create / update" do
     invoice = Quickbooks::Model::Invoice.new
     expect(invoice.valid?).to be false
-    expect(invoice.errors.keys.include?(:customer_ref)).to be true
+    expect(invoice.errors.map(&:attribute).include?(:customer_ref)).to be true
   end
 
   it "is valid with line_items and customer_ref" do
@@ -126,12 +126,12 @@ describe "Quickbooks::Model::Invoice" do
     invoice = Quickbooks::Model::Invoice.new
     invoice.wants_billing_email_sent!
     expect(invoice.valid?).to be false
-    expect(invoice.errors.keys.include?(:bill_email)).to be true
+    expect(invoice.errors.map(&:attribute).include?(:bill_email)).to be true
 
     # now specify an email address it will be valid for this attribute
     invoice.billing_email_address = "foo@example.com"
     expect(invoice.valid?).to be false
-    expect(invoice.errors.keys.include?(:bill_email)).to be false
+    expect(invoice.errors.map(&:attribute).include?(:bill_email)).to be false
   end
 
   it "can load a description-only line item detail from XML" do

--- a/spec/lib/quickbooks/model/item_spec.rb
+++ b/spec/lib/quickbooks/model/item_spec.rb
@@ -21,12 +21,12 @@ describe "Quickbooks::Model::Item" do
   it "must have a name for create / update" do
     item = Quickbooks::Model::Item.new
     expect(item.valid?).to eq(false)
-    expect(item.errors.keys.include?(:name)).to eq(true)
+    expect(item.errors.map(&:attribute).include?(:name)).to eq(true)
 
     # now give it a name
     item.name = "Water Slide"
     item.valid?
-    expect(item.errors.keys.include?(:name)).not_to eq(true)
+    expect(item.errors.map(&:attribute).include?(:name)).not_to eq(true)
   end
 
   it "doesn't set rate_percent unless user explicitly does it" do
@@ -45,11 +45,11 @@ describe "Quickbooks::Model::Item" do
     # an invalid type ...
     item.type = 'Unknown'
     expect(item.valid?).to eq(false)
-    expect(item.errors.keys.include?(:type)).to eq(true)
+    expect(item.errors.map(&:attribute).include?(:type)).to eq(true)
 
     # an valid type ...
     item.type = Quickbooks::Model::Item::INVENTORY_TYPE
     item.valid?
-    expect(item.errors.keys.include?(:type)).not_to eq(true)
+    expect(item.errors.map(&:attribute).include?(:type)).not_to eq(true)
   end
 end

--- a/spec/lib/quickbooks/model/payment_method_spec.rb
+++ b/spec/lib/quickbooks/model/payment_method_spec.rb
@@ -4,14 +4,14 @@ describe Quickbooks::Model::PaymentMethod do
 
     # It should allow nil
     account.valid?
-    expect(account.errors.keys.include?(:type)).to eq(false)
+    expect(account.errors.map(&:attribute).include?(:type)).to eq(false)
 
     account.type = 'Undocummented Type'
     account.valid?
-    expect(account.errors.keys.include?(:type)).to eq(true)
+    expect(account.errors.map(&:attribute).include?(:type)).to eq(true)
 
     account.type = Quickbooks::Model::PaymentMethod::CREDIT_CARD
     account.valid?
-    expect(account.errors.keys.include?(:type)).to eq(false)
+    expect(account.errors.map(&:attribute).include?(:type)).to eq(false)
   end
 end

--- a/spec/lib/quickbooks/model/payment_spec.rb
+++ b/spec/lib/quickbooks/model/payment_spec.rb
@@ -23,7 +23,7 @@ describe "Quickbooks::Model::Payment" do
   it "should require customer_ref for create / update" do
     invoice = Quickbooks::Model::Payment.new
     expect(invoice).not_to be_valid
-    expect(invoice.errors.keys.include?(:customer_ref)).to be true
+    expect(invoice.errors.map(&:attribute).include?(:customer_ref)).to be true
   end
 
   it "is valid with customer_ref" do

--- a/spec/lib/quickbooks/model/refund_receipt_spec.rb
+++ b/spec/lib/quickbooks/model/refund_receipt_spec.rb
@@ -121,14 +121,14 @@ describe "Quickbooks::Model::RefundReceipt" do
       refund_receipt.auto_doc_number!
       refund_receipt.valid?
       expect(refund_receipt.valid?).to eq(false)
-      expect(refund_receipt.errors.keys.include?(:doc_number)).to be true
+      expect(refund_receipt.errors.map(&:attribute).include?(:doc_number)).to be true
     end
 
     it "turned off then doc_number can be specified" do
       refund_receipt = Quickbooks::Model::RefundReceipt.new
       refund_receipt.doc_number = 'AUTO'
       refund_receipt.valid?
-      expect(refund_receipt.errors.keys.include?(:doc_number)).to be false
+      expect(refund_receipt.errors.map(&:attribute).include?(:doc_number)).to be false
     end
   end
 

--- a/spec/lib/quickbooks/model/tax_agency_spec.rb
+++ b/spec/lib/quickbooks/model/tax_agency_spec.rb
@@ -14,7 +14,7 @@ describe "Quickbooks::Model::TaxAgency" do
   it "should require display_name for create / update" do
     invoice = Quickbooks::Model::TaxAgency.new
     expect(invoice).not_to be_valid
-    expect(invoice.errors.keys.include?(:display_name)).to be true
+    expect(invoice.errors.map(&:attribute).include?(:display_name)).to be true
   end
 
 end

--- a/spec/lib/quickbooks/model/tax_service_spec.rb
+++ b/spec/lib/quickbooks/model/tax_service_spec.rb
@@ -3,7 +3,7 @@ describe "Quickbooks::Model::TaxService" do
   it "must include at least one TaxRateDetails item" do
     item = Quickbooks::Model::TaxService.new(tax_code: '123456')
     expect(item).not_to be_valid
-    expect(item.errors.keys.include?(:tax_rate_details)).to be true
+    expect(item.errors.map(&:attribute).include?(:tax_rate_details)).to be true
 
     messages = item.errors.map { |e| e.message }
     expect(messages).to include("must have at least one item")
@@ -47,7 +47,7 @@ describe "Quickbooks::Model::TaxService" do
     )
     item.tax_rate_details << tax_line2
     expect(item).not_to be_valid
-    expect(item.errors.keys.include?(:tax_rate_name)).to be true
+    expect(item.errors.map(&:attribute).include?(:tax_rate_name)).to be true
 
     messages = item.errors.map { |e| e.message }
     expect(messages).to include("Duplicate Tax Rate Name")

--- a/spec/lib/quickbooks/model/vendor_spec.rb
+++ b/spec/lib/quickbooks/model/vendor_spec.rb
@@ -48,14 +48,14 @@ describe "Quickbooks::Model::Vendor" do
     vendor = Quickbooks::Model::Vendor.new
     vendor.email_address = "foo+example.org"
     vendor.valid?
-    expect(vendor.errors.keys).to include(:primary_email_address)
+    expect(vendor.errors.map(&:attribute)).to include(:primary_email_address)
   end
 
   it "cannot update an invalid model" do
     vendor = Quickbooks::Model::Vendor.new
     expect(vendor.valid_for_update?).to eq(false)
     expect(vendor.to_xml_ns).to match('Vendor')
-    expect(vendor.errors.keys).to include(:sync_token)
+    expect(vendor.errors.map(&:attribute)).to include(:sync_token)
   end
 
 end

--- a/spec/lib/quickbooks/service/customer_spec.rb
+++ b/spec/lib/quickbooks/service/customer_spec.rb
@@ -37,7 +37,7 @@ describe "Quickbooks::Service::Customer" do
 
     expect(customer.valid?).to eq(false)
     expect(customer.valid_for_create?).to eq(false)
-    expect(customer.errors.keys.include?(:display_name)).to eq(true)
+    expect(customer.errors.map(&:attribute).include?(:display_name)).to eq(true)
   end
 
   it "cannot create a customer with an invalid email" do
@@ -48,7 +48,7 @@ describe "Quickbooks::Service::Customer" do
     end.to raise_error(Quickbooks::InvalidModelException)
 
     expect(customer.valid?).to eq(false)
-    expect(customer.errors.keys.include?(:primary_email_address)).to eq(true)
+    expect(customer.errors.map(&:attribute).include?(:primary_email_address)).to eq(true)
   end
 
   it "can create a customer" do

--- a/spec/lib/quickbooks/service/employee_spec.rb
+++ b/spec/lib/quickbooks/service/employee_spec.rb
@@ -29,7 +29,7 @@ describe "Quickbooks::Service::Employee" do
     expect(employee.valid?).to eq(false)
     expect(employee.valid_for_create?).to eq(false)
     expect{ @service.create(employee) }.to raise_error(Quickbooks::InvalidModelException, /cannot contain a colon/)
-    expect(employee.errors.keys.include?(:display_name)).to eq(true)
+    expect(employee.errors.map(&:attribute).include?(:display_name)).to eq(true)
   end
 
   it "cannot create an employee with an invalid email" do
@@ -38,7 +38,7 @@ describe "Quickbooks::Service::Employee" do
     expect(employee.valid_for_create?).to eq(false)
     expect(employee.valid?).to eq(false)
     expect{ @service.create(employee) }.to raise_error(Quickbooks::InvalidModelException, /Email address must contain/)
-    expect(employee.errors.keys.include?(:primary_email_address)).to eq(true)
+    expect(employee.errors.map(&:attribute).include?(:primary_email_address)).to eq(true)
   end
 
   it "can create a employee" do

--- a/spec/lib/quickbooks/service/invoice_spec.rb
+++ b/spec/lib/quickbooks/service/invoice_spec.rb
@@ -36,7 +36,7 @@ describe "Quickbooks::Service::Invoice" do
     }.to raise_error(Quickbooks::InvalidModelException, /At least 1 line item is required/)
 
     expect(invoice.valid?).to eq false
-    expect(invoice.errors.keys.include?(:line_items)).to be true
+    expect(invoice.errors.map(&:attribute).include?(:line_items)).to be true
   end
 
   it "is valid when it has 1 or more line items" do
@@ -48,7 +48,7 @@ describe "Quickbooks::Service::Invoice" do
     }.to raise_error(Quickbooks::InvalidModelException)
 
     expect(invoice.valid?).to eq false
-    expect(invoice.errors.keys.include?(:line_items)).to_not be true
+    expect(invoice.errors.map(&:attribute).include?(:line_items)).to_not be true
   end
 
   it "cannot create an Invoice without a CustomerRef" do
@@ -59,7 +59,7 @@ describe "Quickbooks::Service::Invoice" do
     }.to raise_error(Quickbooks::InvalidModelException)
 
     expect(invoice.valid?).to eq false
-    expect(invoice.errors.keys.include?(:customer_ref)).to be true
+    expect(invoice.errors.map(&:attribute).include?(:customer_ref)).to be true
   end
 
   it "is valid when a CustomerRef is specified" do
@@ -71,7 +71,7 @@ describe "Quickbooks::Service::Invoice" do
     }.to raise_error(Quickbooks::InvalidModelException)
 
     expect(invoice.valid?).to eq false
-    expect(invoice.errors.keys.include?(:customer_ref)).to_not be true
+    expect(invoice.errors.map(&:attribute).include?(:customer_ref)).to_not be true
   end
 
   it "can create an Invoice" do

--- a/spec/lib/quickbooks/service/item_spec.rb
+++ b/spec/lib/quickbooks/service/item_spec.rb
@@ -32,7 +32,7 @@ describe "Quickbooks::Service::Item" do
     end.to raise_error(Quickbooks::InvalidModelException)
 
     expect(item.valid?).to eq(false)
-    expect(item.errors.keys.include?(:name)).to eq(true)
+    expect(item.errors.map(&:attribute).include?(:name)).to eq(true)
   end
 
   it "can create an Item" do

--- a/spec/lib/quickbooks/service/purchase_spec.rb
+++ b/spec/lib/quickbooks/service/purchase_spec.rb
@@ -7,7 +7,7 @@ describe "Quickbooks::Service::Purchase" do
   it "cannot create a Purchase without any line items" do
     purchase = Quickbooks::Model::Purchase.new
     expect(purchase.valid?).to be false
-    expect(purchase.errors.keys.include?(:line_items)).to be true
+    expect(purchase.errors.map(&:attribute).include?(:line_items)).to be true
   end
 
   it "created for account based expense" do

--- a/spec/lib/quickbooks/service/time_activity_spec.rb
+++ b/spec/lib/quickbooks/service/time_activity_spec.rb
@@ -29,7 +29,7 @@ describe "Quickbooks::Service::TimeActivity" do
     end.to raise_error(Quickbooks::InvalidModelException)
 
     expect(time_activity.valid?).to eq(false)
-    expect(time_activity.errors.keys.include?(:name_of)).to eq(true)
+    expect(time_activity.errors.map(&:attribute).include?(:name_of)).to eq(true)
   end
 
   it "cannot create a time_activity with an empty employee_ref" do
@@ -40,7 +40,7 @@ describe "Quickbooks::Service::TimeActivity" do
     end.to raise_error(Quickbooks::InvalidModelException)
 
     expect(time_activity.valid?).to eq(false)
-    expect(time_activity.errors.keys.include?(:employee_ref)).to eq(true)
+    expect(time_activity.errors.map(&:attribute).include?(:employee_ref)).to eq(true)
   end
 
   it "cannot create a time_activity with an empty vendor_ref" do
@@ -51,7 +51,7 @@ describe "Quickbooks::Service::TimeActivity" do
     end.to raise_error(Quickbooks::InvalidModelException)
 
     expect(time_activity.valid?).to eq(false)
-    expect(time_activity.errors.keys.include?(:vendor_ref)).to eq(true)
+    expect(time_activity.errors.map(&:attribute).include?(:vendor_ref)).to eq(true)
   end
 
   it "can create a time_activity" do

--- a/spec/lib/quickbooks/service/vendor_spec.rb
+++ b/spec/lib/quickbooks/service/vendor_spec.rb
@@ -29,7 +29,7 @@ describe "Quickbooks::Service::Vendor" do
     expect(vendor.valid?).to eq false
     expect(vendor.valid_for_create?).to eq false
     expect{ @service.create(vendor) }.to raise_error(Quickbooks::InvalidModelException, /cannot contain a colon/)
-    expect(vendor.errors.keys.include?(:display_name)).to eq true
+    expect(vendor.errors.map(&:attribute).include?(:display_name)).to eq true
   end
 
   it "cannot create a vendor with an invalid email" do
@@ -38,7 +38,7 @@ describe "Quickbooks::Service::Vendor" do
     expect(vendor.valid_for_create?).to eq false
     expect(vendor.valid?).to eq false
     expect{ @service.create(vendor) }.to raise_error(Quickbooks::InvalidModelException, /Email address must contain/)
-    expect(vendor.errors.keys.include?(:primary_email_address)).to eq true
+    expect(vendor.errors.map(&:attribute).include?(:primary_email_address)).to eq true
   end
 
   it "can create a vendor" do

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -14,14 +14,14 @@ shared_examples_for "a model that has auto_doc_number support" do |entity|
     invoice.auto_doc_number!
     invoice.valid?
     expect(invoice.valid?).to be false
-    expect(invoice.errors.keys.include?(:doc_number)).to be true
+    expect(invoice.errors.map(&:attribute).include?(:doc_number)).to be true
   end
 
   it "turned off then doc_number can be specified" do
     invoice = model
     invoice.doc_number = 'AUTO'
     invoice.valid?
-    expect(invoice.errors.keys.include?(:doc_number)).to be false
+    expect(invoice.errors.map(&:attribute).include?(:doc_number)).to be false
   end
 end
 
@@ -29,7 +29,7 @@ shared_examples_for "a model with a valid GlobalTaxCalculation" do |value|
   before { subject.global_tax_calculation = value }
   it "does not include an error for global_tax_calculation" do
     subject.valid?
-    expect(subject.errors.keys.include?(:global_tax_calculation)).to be false
+    expect(subject.errors.map(&:attribute).include?(:global_tax_calculation)).to be false
   end
 end
 
@@ -37,6 +37,6 @@ shared_examples_for "a model with an invalid GlobalTaxCalculation" do
   before { subject.global_tax_calculation = "Invalid" }
   it "includes an error for global_tax_calculation" do
     expect(subject.valid?).to be false
-    expect(subject.errors.keys.include?(:global_tax_calculation)).to be true
+    expect(subject.errors.map(&:attribute).include?(:global_tax_calculation)).to be true
   end
 end


### PR DESCRIPTION
Migrate CI to GitHub Actions as Travis CI.org is no longer active.

In addition to adding the config file, I updated the use of `errors.keys` to `errors.map(&:attribute)` the `keys` method on `errors` has been removed.

After the above changes everything runs green on my fork.