### PR TITLE
Add Linked Transactions Array to VendorCredit

### DIFF
--- a/lib/quickbooks/model/vendor_credit.rb
+++ b/lib/quickbooks/model/vendor_credit.rb
@@ -28,6 +28,8 @@ module Quickbooks
 
       xml_accessor :currency_ref, :from => 'CurrencyRef', :as => BaseReference
       xml_accessor :exchange_rate, :from => 'ExchangeRate', :as => BigDecimal, :to_xml => to_xml_big_decimal
+      
+      xml_accessor :linked_transactions, :from => 'LinkedTxn', :as => [LinkedTransaction]
 
       reference_setters
 


### PR DESCRIPTION
Adds ability to access linked transactions on the vendor credit object. For example, if the credit was applied to a bill as payment.