### PR TITLE
deser tax_inclusive_amt to numeric type

### DIFF
--- a/lib/quickbooks/model/account_based_expense_line_detail.rb
+++ b/lib/quickbooks/model/account_based_expense_line_detail.rb
@@ -7,7 +7,7 @@ module Quickbooks
       xml_accessor :billable_status, :from => 'BillableStatus'
       xml_accessor :tax_amount, :from => 'UnitPrice', :as => BigDecimal, :to_xml => to_xml_big_decimal
       xml_accessor :tax_code_ref, :from => 'TaxCodeRef', :as => BaseReference
-      xml_accessor :tax_inclusive_amount, from: 'TaxInclusiveAmt', to_xml: Proc.new { |val| val.to_f }
+      xml_accessor :tax_inclusive_amount, from: 'TaxInclusiveAmt', :as => BigDecimal, to_xml: Proc.new { |val| val.to_f }
 
       reference_setters :customer_ref, :class_ref, :account_ref, :tax_code_ref
 

--- a/lib/quickbooks/model/item_based_expense_line_detail.rb
+++ b/lib/quickbooks/model/item_based_expense_line_detail.rb
@@ -13,7 +13,7 @@ module Quickbooks
       xml_accessor :tax_code_ref, :from => 'TaxCodeRef', :as => BaseReference
       xml_accessor :customer_ref, :from => 'CustomerRef', :as => BaseReference
       xml_accessor :billable_status, :from => 'BillableStatus'
-      xml_accessor :tax_inclusive_amount, from: 'TaxInclusiveAmt', to_xml: Proc.new { |val| val.to_f }
+      xml_accessor :tax_inclusive_amount, from: 'TaxInclusiveAmt', :as => BigDecimal, to_xml: Proc.new { |val| val.to_f }
 
       reference_setters :item_ref, :class_ref, :price_level_ref, :customer_ref, :tax_code_ref
     end

--- a/lib/quickbooks/model/sales_item_line_detail.rb
+++ b/lib/quickbooks/model/sales_item_line_detail.rb
@@ -9,7 +9,7 @@ module Quickbooks
       xml_accessor :quantity, :from => 'Qty', :as => BigDecimal, :to_xml => Proc.new { |val| val.to_f }
       xml_accessor :tax_code_ref, :from => 'TaxCodeRef', :as => BaseReference
       xml_accessor :service_date, :from => 'ServiceDate', :as => Date
-      xml_accessor :tax_inclusive_amount, from: 'TaxInclusiveAmt', to_xml: Proc.new { |val| val.to_f }
+      xml_accessor :tax_inclusive_amount, from: 'TaxInclusiveAmt', :as => BigDecimal, to_xml: Proc.new { |val| val.to_f }
 
       reference_setters :item_ref, :class_ref, :price_level_ref, :tax_code_ref
     end

--- a/spec/fixtures/bill_create_response.xml
+++ b/spec/fixtures/bill_create_response.xml
@@ -16,6 +16,7 @@
             <AccountRef name="Bank Loan">42</AccountRef>
             <BillableStatus>NotBillable</BillableStatus>
             <TaxCodeRef>NON</TaxCodeRef>
+            <TaxInclusiveAmt>0.0</TaxInclusiveAmt>
         </AccountBasedExpenseLineDetail>
     </Line>
     <Line>
@@ -27,6 +28,7 @@
             <AccountRef name="Interest Expense">77</AccountRef>
             <BillableStatus>NotBillable</BillableStatus>
             <TaxCodeRef>NON</TaxCodeRef>
+            <TaxInclusiveAmt>0.0</TaxInclusiveAmt>
         </AccountBasedExpenseLineDetail>
     </Line>
     <VendorRef name="Great Statewide Bank">4</VendorRef>

--- a/spec/fixtures/sales_receipt.xml
+++ b/spec/fixtures/sales_receipt.xml
@@ -19,6 +19,8 @@
       <ItemRef name="Sales">1</ItemRef>
       <UnitPrice>10</UnitPrice>
       <Qty>1</Qty>
+      <TaxCodeRef>NON</TaxCodeRef>
+      <TaxInclusiveAmt>0.0</TaxInclusiveAmt>
     </SalesItemLineDetail>
   </Line>
   <Line>

--- a/spec/lib/quickbooks/model/bill_spec.rb
+++ b/spec/lib/quickbooks/model/bill_spec.rb
@@ -23,6 +23,7 @@ describe "Quickbooks::Model::Bill" do
     expect(line_item1.account_based_expense_line_detail.class_ref.value).to eq "100000000000128320"
     expect(line_item1.account_based_expense_line_detail.class_ref.name).to eq "Overhead"
     expect(line_item1.account_based_expense_line_detail.tax_code_ref.to_s).to eq "NON"
+    expect(line_item1.account_based_expense_line_detail.tax_inclusive_amount).to eq 0.0
 
     line_item2 = bill.line_items[1]
     expect(line_item2.id).to eq "2"
@@ -34,6 +35,8 @@ describe "Quickbooks::Model::Bill" do
     expect(line_item2.account_based_expense_line_detail.class_ref.value).to eq "100000000000128320"
     expect(line_item2.account_based_expense_line_detail.class_ref.name).to eq "Overhead"
     expect(line_item2.account_based_expense_line_detail.tax_code_ref.to_s).to eq "NON"
+    expect(line_item2.account_based_expense_line_detail.tax_inclusive_amount).to eq 0.0
+
   end
 
   it "can parse an Item-based bill from XML" do

--- a/spec/lib/quickbooks/model/sales_receipt_spec.rb
+++ b/spec/lib/quickbooks/model/sales_receipt_spec.rb
@@ -21,6 +21,7 @@ describe "Quickbooks::Model::SalesReceipt" do
     expect(sales_receipt.line_items.first.sales_item_line_detail.item_ref.value).to eq("1")
     expect(sales_receipt.line_items.first.sales_item_line_detail.unit_price).to eq(10)
     expect(sales_receipt.line_items.first.sales_item_line_detail.quantity).to eq(1)
+    expect(sales_receipt.line_items.first.sales_item_line_detail.tax_inclusive_amount).to eq(0.0)
 
     expect(sales_receipt.line_items[1]).not_to be_nil
     expect(sales_receipt.line_items[1].amount).to eq(10.00)


### PR DESCRIPTION
Fix for https://github.com/ruckus/quickbooks-ruby/issues/588:  match the numeric serialization type for this field, across models where used.