### PR TITLE
Add support for sending remaining options with query

### DIFF
--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -83,7 +83,11 @@ module Quickbooks
         query ||= default_model_query
         query = "#{query} STARTPOSITION #{start_position} MAXRESULTS #{max_results}"
 
-        "#{url_for_base}/query?query=#{CGI.escape(query)}"
+        URI("#{url_for_base}/query").tap do |uri|
+          params = Faraday::Utils::ParamsHash.new
+          params.update(options.merge(query: query))
+          uri.query = params.to_query
+        end.to_s
       end
 
       private
@@ -116,7 +120,7 @@ module Quickbooks
         start_position = ((page - 1) * per_page) + 1 # page=2, per_page=10 then we want to start at 11
         max_results = per_page
 
-        response = do_http_get(url_for_query(query, start_position, max_results))
+        response = do_http_get(url_for_query(query, start_position, max_results, options.except(:page, :per_page)))
 
         parse_collection(response, model)
       end


### PR DESCRIPTION
+ Append all non-standard options to the query url
+ Rely on Faraday's query string encoding

Some endpoints (like invoice) require additional parameters on the query URL to get additional attributes (like include=invoiceLink).