### PR TITLE
Faraday Versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,11 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["2.6", "2.7", "3.0", "3.1", ruby-head]
+        env:
+          - FARADAY_VERSION: "~> 2.0"
+          - FARADAY_VERSION: "~> 1.0"
 
+    env: ${{ matrix.env }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,7 @@ ruby RUBY_VERSION
 gem 'pry'
 
 gemspec
+
+if ENV['FARADAY_VERSION']
+  gem 'faraday', ENV['FARADAY_VERSION']
+end

--- a/lib/quickbooks/service/access_token.rb
+++ b/lib/quickbooks/service/access_token.rb
@@ -22,7 +22,12 @@ module Quickbooks
       def disconnect
         connection = Faraday.new(headers: { 'Content-Type' => 'application/json' }) do |f|
           f.adapter(::Quickbooks.http_adapter)
-          f.request(:authorization, :basic, oauth.client.id, oauth.client.secret)
+
+          if Gem.loaded_specs['faraday'].version >= Gem::Version.create('2.0')
+            f.request(:authorization, :basic, oauth.client.id, oauth.client.secret)
+          else
+            f.basic_auth(oauth.client.id, oauth.client.secret)
+          end
         end
 
         url = "#{DISCONNECT_URL}?minorversion=#{Quickbooks.minorversion}"


### PR DESCRIPTION
Both Faraday 1.x and 2x are allowed dependencies, but the released code currently breaks with Faraday 1.x - one example is reported in #587.

If 2.x is not going to be required, the gem needs to be tested against and support both versions.

This PR adds Faraday 1.x to the test matrix, with the goal of revealing broken tests so they can be addressed.