### PR TITLE
Use Faraday::UploadIO instead of UploadIO

### DIFF
--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -224,7 +224,7 @@ module Quickbooks
         if metadata
           standalone_prefix = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
           meta_data_xml = "#{standalone_prefix}\n#{metadata.to_xml_ns.to_s}"
-          param_part = UploadIO.new(StringIO.new(meta_data_xml), "application/xml")
+          param_part = Faraday::UploadIO.new(StringIO.new(meta_data_xml), "application/xml")
           body['file_metadata_0'] = param_part
         end
 
@@ -369,7 +369,7 @@ module Quickbooks
             body.each do |k,v|
               messages << 'BODY PART:'
               val_content = v.inspect
-              if v.is_a?(UploadIO)
+              if v.is_a?(Faraday::UploadIO)
                 if v.content_type == 'application/xml'
                   if v.io.is_a?(StringIO)
                     val_content = log_xml(v.io.string)

--- a/lib/quickbooks/service/upload.rb
+++ b/lib/quickbooks/service/upload.rb
@@ -9,7 +9,7 @@ module Quickbooks
       # attachable: Quickbooks::Model::Attachable meta-data details, can be null
       def upload(path_to_file, mime_type, attachable = nil)
         url = url_for_resource("upload")
-        uploadIO = class_for_io.new(path_to_file, mime_type)
+        uploadIO = Faraday::UploadIO.new(path_to_file, mime_type)
         response = do_http_file_upload(uploadIO, url, attachable)
         prefix = "AttachableResponse/xmlns:Attachable"
         if response.code.to_i == 200
@@ -17,10 +17,6 @@ module Quickbooks
         else
           nil
         end
-      end
-
-      def class_for_io
-        oauth.is_a?(OAuth2::AccessToken) ? Faraday::UploadIO : UploadIO
       end
 
       def download(uploadId)

--- a/quickbooks-ruby.gemspec
+++ b/quickbooks-ruby.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'nokogiri'  # promiscuous mode
   gem.add_dependency 'multipart-post' # promiscuous mode
   gem.add_dependency 'faraday', '< 3.0'
-  gem.add_dependency 'faraday-multipart', '~> 1.0'
+  gem.add_dependency 'faraday-multipart', '~> 1.0', '>= 1.0.4'
   gem.add_dependency 'faraday-gzip', '~> 1.0'
 
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
This changes all reference of the deprecated `::UploadIO` for `Faraday::UploadIO`. `multipart-post 2.2.0` deprecates top-level `UploadIO`: https://github.com/socketry/multipart-post/commit/cb18a32ed9522af9e4072195d0411a8281c6a061#diff-f192e4f2c6b7ce852ab54997f6dec1141f625ccd9d02a002b1a8adc39033c250

I decided to just use Faraday's alias of `UploadIO` since they check the first of `mutlipart-post` you're on and alias the constant properly. I also added `>= 1.0.4` for `multipart-post`...since `Faraday::UploadIO` wasn't introduced until 1.0.2 anyways. So, I'm not sure how this was working for folks with `multipart-post 1.0.0 or 1.0.1`: https://github.com/ruckus/quickbooks-ruby/blob/2.0.2/lib/quickbooks/service/upload.rb#L23