### PR TITLE
Add element to IntuitRequestException and message

### DIFF
--- a/lib/quickbooks-ruby.rb
+++ b/lib/quickbooks-ruby.rb
@@ -275,7 +275,7 @@ module Quickbooks
   class UnsupportedOperation < Error; end
 
   class IntuitRequestException < Error
-    attr_accessor :message, :code, :detail, :type, :intuit_tid, :request_xml, :request_json
+    attr_accessor :message, :code, :detail, :element, :type, :intuit_tid, :request_xml, :request_json
 
     def initialize(msg)
       self.message = msg

--- a/lib/quickbooks/service/base_service.rb
+++ b/lib/quickbooks/service/base_service.rb
@@ -416,10 +416,12 @@ module Quickbooks
 
       def parse_and_raise_exception(options = {})
         err = parse_intuit_error
-        ex = Quickbooks::IntuitRequestException.new("#{err[:message]}:\n\t#{err[:detail]}")
+        element_msg = err[:element] ? "#{err[:element]}: " : ""
+        ex = Quickbooks::IntuitRequestException.new("#{element_msg}#{err[:message]}:\n\t#{err[:detail]}")
         ex.code = err[:code]
         ex.detail = err[:detail]
         ex.type = err[:type]
+        ex.element = err[:element] if err[:element]
         if is_json?
           ex.request_json = options[:request]
         else
@@ -451,7 +453,7 @@ module Quickbooks
             end
             element_attr = error_element.attributes['element']
             if element_attr
-              error[:element] = code_attr.try(:value)
+              error[:element] = element_attr.try(:value)
             end
             error[:message] = error_element.xpath("//xmlns:Message").try(:text)
             error[:detail] = error_element.xpath("//xmlns:Detail").try(:text)

--- a/spec/fixtures/item_name_too_long_error.xml
+++ b/spec/fixtures/item_name_too_long_error.xml
@@ -1,0 +1,8 @@
+<IntuitResponse xmlns="http://schema.intuit.com/finance/v3" time="2024-04-09T07:52:37.581-07:00">
+  <Fault type="ValidationFault">
+    <Error code="2050" element="Name">
+      <Message>String length is either shorter or longer than supported by specification</Message>
+      <Detail>String length specified does not match the supported length. Min:0 Max:100 supported. Supplied length:103</Detail>
+    </Error>
+  </Fault>
+</IntuitResponse>

--- a/spec/lib/quickbooks/service/base_service_spec.rb
+++ b/spec/lib/quickbooks/service/base_service_spec.rb
@@ -58,6 +58,19 @@ describe Quickbooks::Service::BaseService do
       expect { @service.send(:check_response, response) }.to raise_error(Quickbooks::IntuitRequestException)
     end
 
+    it "should parse all the error fields" do
+      xml = fixture('item_name_too_long_error.xml')
+      response = Struct.new(:code, :plain_body).new(400, xml)
+      expect { @service.send(:check_response, response, :request => xml) }.to raise_error { |error|
+        expect(error.type).to eq "ValidationFault"
+        expect(error.code).to eq "2050"
+        expect(error.element).to eq "Name"
+        expect(error.detail).to eq "String length specified does not match the supported length. Min:0 Max:100 supported. Supplied length:103"
+        expect(error.message).to include "String length is either shorter or longer than supported by specification"
+        expect(error.message).to include "String length specified does not match the supported length. Min:0 Max:100 supported. Supplied length:103"
+      }
+    end
+
     it "should add request xml to request exception" do
       xml = fixture('generic_error.xml')
       xml2 = fixture('customer.xml')


### PR DESCRIPTION
Have you error received a field error like "String length specified does not match the supported length" and wondered which of the many fields caused the issue? Me too, this PR changes all that :-)

My proposal makes the element (field) available in the IntuitRequestException for programatic access to the element name associated with the error message. It also adds the element name if present (it's optional) to the exception message so that messages are prepended with the specific field if present.

Tradeoffs: Adding the element name to the exception message could break existing code if logic was based on the EXACT message returned. Logic based on an exact match instead of an includes would be brittle to message changes from QBO and is a bad practice. I think it's a good tradeoff to add the element name to the message which is generally used everywhere as by default error messages will now indicate which element they apply to. The message already concatenates the underlying error message and error detail fields and this seemed like very useful context to add to the message by default.