### PR TITLE
Loosen faraday-gzip to a version that can use > zlib-2.1.1

### DIFF
--- a/quickbooks-ruby.gemspec
+++ b/quickbooks-ruby.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'multipart-post' # promiscuous mode
   gem.add_dependency 'faraday', '< 3.0'
   gem.add_dependency 'faraday-multipart', '~> 1.0', '>= 1.0.4'
-  gem.add_dependency 'faraday-gzip', '~> 1.0'
+  gem.add_dependency 'faraday-gzip', '>= 1.0'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'simplecov'


### PR DESCRIPTION
I was looking to update our app from using zlib 2.1.1 to the latest zlib-3.1.1, but bundler wasn't able to update it. I tracked down the dependency chain to:

- faraday-gzip-1.0.1 depends on  zlib `~> 2.1`, which resolves to zlib-2.1.1
- quickbook-ruby depends on faraday-gzip `~> 1.0` which resolves to faraday-gzip-1.0.1

This PR tries to loosen the dependency to `>= 1.0`. I'm open to other variations that would allow faraday-gzip-2 though.