### PR TITLE
Add ship from address reference to sales receipt

### DIFF
--- a/lib/quickbooks/model/sales_receipt.rb
+++ b/lib/quickbooks/model/sales_receipt.rb
@@ -22,6 +22,7 @@ module Quickbooks
       xml_accessor :bill_address, :from => 'BillAddr', :as => PhysicalAddress
       xml_accessor :delivery_info, :from => 'DeliveryInfo', :as => DeliveryInfo
       xml_accessor :ship_address, :from => 'ShipAddr', :as => PhysicalAddress
+      xml_accessor :ship_from_address, :from => 'ShipFromAddr', :as => PhysicalAddress
       xml_accessor :po_number, :from => 'PONumber'
       xml_accessor :ship_method_ref, :from => 'ShipMethodRef', :as => BaseReference
       xml_accessor :ship_date, :from => 'ShipDate', :as => Time

--- a/spec/fixtures/sales_receipt.xml
+++ b/spec/fixtures/sales_receipt.xml
@@ -56,4 +56,14 @@
   <EmailStatus>NotSet</EmailStatus>
   <Balance>0</Balance>
   <DepositToAccountRef name="Cash and cash equivalents">28</DepositToAccountRef>
+  <ShipFromAddr>
+    <Id>5</Id>
+    <Line1>1040 East Tasman Drive.</Line1>
+    <City>Los Angeles</City>
+    <Country>USA</Country>
+    <CountrySubDivisionCode>CA</CountrySubDivisionCode>
+    <PostalCode>91123</PostalCode>
+    <Lat>33.739466</Lat>
+    <Long>-118.0395574</Long>
+  </ShipFromAddr>
 </SalesReceipt>

--- a/spec/fixtures/sales_receipt.xml
+++ b/spec/fixtures/sales_receipt.xml
@@ -56,6 +56,25 @@
   <EmailStatus>NotSet</EmailStatus>
   <Balance>0</Balance>
   <DepositToAccountRef name="Cash and cash equivalents">28</DepositToAccountRef>
+  <BillAddr>
+    <Id>6</Id>
+    <Line1>Rebecca Clark</Line1>
+    <Line2>Sunset Bakery</Line2>
+    <Line3>1040 East Tasman Drive.</Line3>
+    <Line4>Los Angeles, CA  91123 USA</Line4>
+    <Lat>34.1426959</Lat>
+    <Long>-118.1568847</Long>
+  </BillAddr>
+  <ShipAddr>
+    <Id>3</Id>
+    <Line1>1040 East Tasman Drive.</Line1>
+    <City>Los Angeles</City>
+    <Country>USA</Country>
+    <CountrySubDivisionCode>CA</CountrySubDivisionCode>
+    <PostalCode>91123</PostalCode>
+    <Lat>33.739466</Lat>
+    <Long>-118.0395574</Long>
+  </ShipAddr>
   <ShipFromAddr>
     <Id>5</Id>
     <Line1>1040 East Tasman Drive.</Line1>

--- a/spec/fixtures/sales_receipt_void_success_response.xml
+++ b/spec/fixtures/sales_receipt_void_success_response.xml
@@ -80,6 +80,16 @@
       <Lat>INVALID</Lat>
       <Long>INVALID</Long>
     </ShipAddr>
+    <ShipFromAddr>
+      <Id>5</Id>
+      <Line1>1040 East Tasman Drive.</Line1>
+      <City>Los Angeles</City>
+      <Country>USA</Country>
+      <CountrySubDivisionCode>CA</CountrySubDivisionCode>
+      <PostalCode>91123</PostalCode>
+      <Lat>33.739466</Lat>
+      <Long>-118.0395574</Long>
+    </ShipFromAddr>
     <GlobalTaxCalculation>NotApplicable</GlobalTaxCalculation>
     <TotalAmt>10.00</TotalAmt>
     <PrintStatus>NotSet</PrintStatus>

--- a/spec/fixtures/sales_receipts.xml
+++ b/spec/fixtures/sales_receipts.xml
@@ -82,6 +82,16 @@
         <Lat>INVALID</Lat>
         <Long>INVALID</Long>
       </ShipAddr>
+      <ShipFromAddr>
+        <Id>5</Id>
+        <Line1>1040 East Tasman Drive.</Line1>
+        <City>Los Angeles</City>
+        <Country>USA</Country>
+        <CountrySubDivisionCode>CA</CountrySubDivisionCode>
+        <PostalCode>91123</PostalCode>
+        <Lat>33.739466</Lat>
+        <Long>-118.0395574</Long>
+      </ShipFromAddr>
       <GlobalTaxCalculation>NotApplicable</GlobalTaxCalculation>
       <TotalAmt>10.00</TotalAmt>
       <PrintStatus>NotSet</PrintStatus>

--- a/spec/lib/quickbooks/model/sales_receipt_spec.rb
+++ b/spec/lib/quickbooks/model/sales_receipt_spec.rb
@@ -55,6 +55,17 @@ describe "Quickbooks::Model::SalesReceipt" do
     expect(sales_receipt.private_note).to eq("private")
 
     expect(sales_receipt.total).to eq(10.00)
+
+    ship_from_address = sales_receipt.ship_from_address
+    expect(ship_from_address).to_not be_nil
+    expect(ship_from_address.id).to eq "5"
+    expect(ship_from_address.line1).to eq "1040 East Tasman Drive."
+    expect(ship_from_address.city).to eq "Los Angeles"
+    expect(ship_from_address.country).to eq "USA"
+    expect(ship_from_address.country_sub_division_code).to eq "CA"
+    expect(ship_from_address.postal_code).to eq "91123"
+    expect(ship_from_address.lat).to eq "33.739466"
+    expect(ship_from_address.lon).to eq "-118.0395574"
   end
 
   it "should initialize line items as empty array" do

--- a/spec/lib/quickbooks/model/sales_receipt_spec.rb
+++ b/spec/lib/quickbooks/model/sales_receipt_spec.rb
@@ -56,6 +56,27 @@ describe "Quickbooks::Model::SalesReceipt" do
 
     expect(sales_receipt.total).to eq(10.00)
 
+    billing_address = sales_receipt.bill_address
+    expect(billing_address).to_not be_nil
+    expect(billing_address.id).to eq "6"
+    expect(billing_address.line1).to eq "Rebecca Clark"
+    expect(billing_address.line2).to eq "Sunset Bakery"
+    expect(billing_address.line3).to eq "1040 East Tasman Drive."
+    expect(billing_address.line4).to eq "Los Angeles, CA  91123 USA"
+    expect(billing_address.lat).to eq "34.1426959"
+    expect(billing_address.lon).to eq "-118.1568847"
+
+    shipping_address = sales_receipt.ship_address
+    expect(shipping_address).to_not be_nil
+    expect(shipping_address.id).to eq "3"
+    expect(shipping_address.line1).to eq "1040 East Tasman Drive."
+    expect(shipping_address.city).to eq "Los Angeles"
+    expect(shipping_address.country).to eq "USA"
+    expect(shipping_address.country_sub_division_code).to eq "CA"
+    expect(shipping_address.postal_code).to eq "91123"
+    expect(shipping_address.lat).to eq "33.739466"
+    expect(shipping_address.lon).to eq "-118.0395574"
+
     ship_from_address = sales_receipt.ship_from_address
     expect(ship_from_address).to_not be_nil
     expect(ship_from_address.id).to eq "5"


### PR DESCRIPTION
Analogous to https://github.com/ruckus/quickbooks-ruby/pull/536 for Sales Receipt.

Also added some minor additional expects for coverage.