### PR TITLE
added pdf method to refund_receipt.rb

### DIFF
--- a/lib/quickbooks/service/refund_receipt.rb
+++ b/lib/quickbooks/service/refund_receipt.rb
@@ -6,6 +6,12 @@ module Quickbooks
         delete_by_query_string(refund_receipt)
       end
 
+      def pdf(refund_receipt)
+        url = "#{url_for_resource(model::REST_RESOURCE)}/#{refund_receipt.id}/pdf"
+        response = do_http_raw_get(url, {}, {'Accept' => 'application/pdf'})
+        response.plain_body
+      end
+
       private
 
       def model


### PR DESCRIPTION
Refund receipt is missing pdf method, the api does support it, so lets add it :)

https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/refundreceipt#get-a-refund-receipt-as-pdf