### PR TITLE
feat: set minor version to 75 & add docs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+## Unreleased (Unreleased)
+
+* Set minimum minor version to 75 per QB
+* Add minor version section via the readme
+
 ## 2.0.5 (2024-07-25)
 
 * Added BCC field to Bill Model. Integrated the PR manually. https://github.com/ruckus/quickbooks-ruby/pull/614 Thanks @hammad-Ikhlaq-7vals

--- a/README.md
+++ b/README.md
@@ -777,6 +777,19 @@ Quickbooks.log = true
 Quickbooks.log_xml_pretty_print = false
 ```
 
+## Minorversion
+
+NOTE
+-----
+The default is `75` due to Quickbooks ignoring all prior versions starting 2025-08-01 ([source](https://blogs.intuit.com/2025/01/21/changes-to-our-accounting-api-that-may-impact-your-application/)).
+-----
+
+You can change the minor version that is used on a global scale (like in an initializer file):
+
+```ruby
+Quickbooks.minorversion = 75
+```
+
 ## Debugging
 
 While logging is helpful the best debugging (in my opinion) is available by using a HTTP proxy such as [Charles Proxy](https://www.charlesproxy.com/).

--- a/lib/quickbooks-ruby.rb
+++ b/lib/quickbooks-ruby.rb
@@ -191,7 +191,7 @@ require 'quickbooks/service/refund_receipt_change'
 module Quickbooks
   @@sandbox_mode = false
   @@logger = nil
-  @@minorversion = 47
+  @@minorversion = 75
   @@http_adapter = :net_http
 
   class << self


### PR DESCRIPTION
* Set the minor version to 75 as that will be the new default via QBO API

* Add a section via the readme about the minor version and why the default is 75

closes ruckus/quickbooks-ruby#622