### PR TITLE
Dup as_json options if frozen for Rails 8 compatibility

### DIFF
--- a/lib/quickbooks/model/base_model.rb
+++ b/lib/quickbooks/model/base_model.rb
@@ -30,6 +30,7 @@ module Quickbooks
 
       def as_json(options = nil)
         options = {} if options.nil?
+        options = options.dup if options.frozen?
         except_conditions = ["roxml_references"]
         except_conditions << options[:except]
         options[:except] = except_conditions.flatten.uniq.compact


### PR DESCRIPTION
Rails 8.0 [introduced a change](https://github.com/rails/rails/pull/52826) which freezes the `options` hash in ActiveSupport's `.as_json` method.

quickbooks-ruby overrides this method to add some ROXML exclusions, and this now breaks after updating to Rails 8. 

```rb
# e.g. from calling `Quickbooks::Service::TaxCode.new(...).fetch_by_id(...).as_json`
FrozenError:
  can't modify frozen Hash: {except: ["roxml_references"]}
/cache/gems/ruby/3.4.0/gems/quickbooks-ruby-2.0.5/lib/quickbooks/model/base_model.rb:35:in 'Quickbooks::Model::BaseModel#as_json'
/cache/gems/ruby/3.4.0/gems/activesupport-8.0.1/lib/active_support/core_ext/object/json.rb:192:in 'block in Hash#as_json'
/cache/gems/ruby/3.4.0/gems/activesupport-8.0.1/lib/active_support/core_ext/object/json.rb:192:in 'Hash#each'
/cache/gems/ruby/3.4.0/gems/activesupport-8.0.1/lib/active_support/core_ext/object/json.rb:192:in 'Hash#as_json'
/cache/gems/ruby/3.4.0/gems/activesupport-8.0.1/lib/active_support/core_ext/object/json.rb:63:in 'Object#as_json'
/cache/gems/ruby/3.4.0/gems/quickbooks-ruby-2.0.5/lib/quickbooks/model/base_model.rb:36:in 'Quickbooks::Model::BaseModel#as_json'
```

The change also [broke some other packages](https://github.com/rails/rails/pull/52826#discussion_r1752237530) which do similar things.

This PR adds a check to `dup` the hash if it's frozen so it can be modified which avoids the issue.