### PR TITLE
Fix vendor and purchases preferences xml reader

### DIFF
--- a/lib/quickbooks/model/preferences.rb
+++ b/lib/quickbooks/model/preferences.rb
@@ -19,7 +19,7 @@ module Quickbooks
       PREFERENCE_SECTIONS = {
         :accounting_info      => %w(TrackDepartments DepartmentTerminology ClassTrackingPerTxnLine? ClassTrackingPerTxn? CustomerTerminology),
         :product_and_services => %w(ForSales? ForPurchase? QuantityWithPriceAndRate? QuantityOnHand?),
-        :vendor_and_purchase  => %w(TrackingByCustomer? BillableExpenseTracking? DefaultTerms? DefaultMarkup? POCustomField),
+        :vendor_and_purchases => %w(TrackingByCustomer? BillableExpenseTracking? DefaultTerms? DefaultMarkup? POCustomField),
         :time_tracking        => %w(UseServices? BillCustomers? ShowBillRateToAll WorkWeekStartDate MarkTimeEntiresBillable?),
         :tax                  => %w(UsingSalesTax? PartnerTaxEnabled?),
         :currency             => %w(MultiCurrencyEnabled? HomeCurrency),


### PR DESCRIPTION
The key is `VendorAndPurchasesPrefs` (purchases is plural), so fix the xml reader.

https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/preferences
